### PR TITLE
Fix an error on CircleCI

### DIFF
--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rubocop', '>= 0.74'
-  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
This PR fixes the following CI error.

```console
$ #!/bin/bash -eo pipefail
bundle install
The git source `git://github.com/rubocop-hq/rubocop.git` uses the `git`
protocol, which transmits data without encryption. Disable this warning
with `bundle config git.allow_insecure true`, or switch to the `https`
protocol to keep your data secure.
Fetching git://github.com/rubocop-hq/rubocop.git
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 2.0)

  Current Bundler version:
    bundler (1.17.3)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 2.0)' in any of the relevant sources:
  the local ruby installation
Exited with code 6
```

https://circleci.com/gh/rubocop-hq/rubocop-minitest/5