### PR TITLE
Added cop to enforce assert truthy over assert_equal(true, actual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features
 
 * [#11](https://github.com/rubocop-hq/rubocop-minitest/pull/11): Add new `Minitest/RefuteNil` cop. ([@tejasbubane ][])
+* [#8](https://github.com/rubocop-hq/rubocop-minitest/pull/8): Add new `Minitest/AssertTruthy` cop. ([@abhaynikam ][])
 
 ## 0.1.0 (2019-09-01)
 
@@ -14,3 +15,4 @@
 [@koic]: https://github.com/koic
 [@duduribeiro]: https://github.com/duduribeiro
 [@tejasbubane]: https://github.com/tejasbubane
+[@abhaynikam]: https://github.com/abhaynikam

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,12 @@ Minitest/AssertNil:
   Enabled: true
   VersionAdded: '0.1'
 
+Minitest/AssertTruthy:
+  Description: 'Check if your test uses `assert(actual)` instead of `assert_equal(true, actual)`.'
+  StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-truthy'
+  Enabled: true
+  VersionAdded: '0.2'
+
 Minitest/RefuteNil:
   Description: 'Check if your test uses `refute_nil` instead of `refute_equal(nil, something)`.'
   StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#refute-nil'

--- a/lib/rubocop/cop/minitest/assert_truthy.rb
+++ b/lib/rubocop/cop/minitest/assert_truthy.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Minitest
+      # Check if your test uses `assert(actual)`
+      # instead of `assert_equal(true, actual)`.
+      #
+      # @example
+      #   # bad
+      #   assert_equal(true, actual)
+      #   assert_equal(true, actual, 'the message')
+      #
+      #   # good
+      #   assert(actual)
+      #   assert(actual, 'the message')
+      #
+      class AssertTruthy < Cop
+        MSG = 'Prefer using `assert(%<arguments>s)` over ' \
+              '`assert_equal(true, %<arguments>s)`.'
+
+        def_node_matcher :assert_equal_with_truthy, <<~PATTERN
+          (send nil? :assert_equal true $_ $...)
+        PATTERN
+
+        def on_send(node)
+          assert_equal_with_truthy(node) do |actual, rest_receiver_arg|
+            message = rest_receiver_arg.first
+
+            arguments = [actual.source, message&.source].compact.join(', ')
+
+            add_offense(node, message: format(MSG, arguments: arguments))
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            arguments = node.arguments.reject(&:true_type?)
+            replacement = arguments.map(&:source).join(', ')
+            corrector.replace(node.loc.expression, "assert(#{replacement})")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/minitest_cops.rb
+++ b/lib/rubocop/cop/minitest_cops.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require_relative 'minitest/assert_nil'
+require_relative 'minitest/assert_truthy'
 require_relative 'minitest/refute_nil'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -2,6 +2,7 @@
 #### Department [Minitest](cops_minitest.md)
 
 * [Minitest/AssertNil](cops_minitest.md#minitestassertnil)
+* [Minitest/AssertTruthy](cops_minitest.md#minitestasserttruthy)
 * [Minitest/RefuteNil](cops_minitest.md#minitestrefutenil)
 
 <!-- END_COP_LIST -->

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -24,6 +24,31 @@ assert_nil(actual, 'the message')
 
 * [https://github.com/rubocop-hq/minitest-style-guide#assert-nil](https://github.com/rubocop-hq/minitest-style-guide#assert-nil)
 
+## Minitest/AssertTruthy
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.2 | -
+
+Check if your test uses `assert(actual)`
+instead of `assert_equal(true, actual)`.
+
+### Examples
+
+```ruby
+# bad
+assert_equal(true, actual)
+assert_equal(true, actual, 'the message')
+
+# good
+assert(actual)
+assert(actual, 'the message')
+```
+
+### References
+
+* [https://github.com/rubocop-hq/minitest-style-guide#assert-truthy](https://github.com/rubocop-hq/minitest-style-guide#assert-truthy)
+
 ## Minitest/RefuteNil
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/minitest/assert_truthy_test.rb
+++ b/test/rubocop/cop/minitest/assert_truthy_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AssertTruthyTest < Minitest::Test
+  def setup
+    @cop = RuboCop::Cop::Minitest::AssertTruthy.new
+  end
+
+  def test_adds_offense_for_use_of_assert_equal_true
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(true, somestuff)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert(somestuff)` over `assert_equal(true, somestuff)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(somestuff)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_equal_true_with_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(true, somestuff, 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert(somestuff, 'the message')` over `assert_equal(true, somestuff, 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(somestuff, 'the message')
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_equal_with_a_method_call
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(true, obj.is_something?, 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert(obj.is_something?, 'the message')` over `assert_equal(true, obj.is_something?, 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(obj.is_something?, 'the message')
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_equal_with_a_string_variable_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          assert_equal(true, somestuff, message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert(somestuff, message)` over `assert_equal(true, somestuff, message)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          assert(somestuff, message)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_equal_with_a_constant_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          assert_equal(true, somestuff, MESSAGE)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert(somestuff, MESSAGE)` over `assert_equal(true, somestuff, MESSAGE)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          assert(somestuff, MESSAGE)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_offend_if_using_assert
+    assert_no_offenses(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_somethingra
+          assert(somestuff)
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
PR adds cops to enforce use of `assert` over `assert_equal(true, actual)`. 

Ref: https://github.com/rubocop-hq/minitest-style-guide#assert-truthy