### PR TITLE
Added a cop to enforce assert_includes over assert(collection.includes?(actual))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#11](https://github.com/rubocop-hq/rubocop-minitest/pull/11): Add new `Minitest/RefuteNil` cop. ([@tejasbubane ][])
 * [#8](https://github.com/rubocop-hq/rubocop-minitest/pull/8): Add new `Minitest/AssertTruthy` cop. ([@abhaynikam ][])
+* [#9](https://github.com/rubocop-hq/rubocop-minitest/pull/9): Add new `Minitest/AssertIncludes` cop. ([@abhaynikam ][])
 
 ## 0.1.0 (2019-09-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,12 @@ Minitest/AssertNil:
   Enabled: true
   VersionAdded: '0.1'
 
+Minitest/AssertIncludes:
+  Description: 'Check if your test uses `assert_includes` instead of `assert(collection.includes?(actual))`.'
+  StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-includes'
+  Enabled: true
+  VersionAdded: '0.2'
+
 Minitest/AssertTruthy:
   Description: 'Check if your test uses `assert(actual)` instead of `assert_equal(true, actual)`.'
   StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-truthy'

--- a/lib/rubocop/cop/minitest/assert_includes.rb
+++ b/lib/rubocop/cop/minitest/assert_includes.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Minitest
+      # Check if your test uses `assert_includes`
+      # instead of `assert(collection.includes?(actual))`.
+      #
+      # @example
+      #   # bad
+      #   assert(collection.includes?(actual))
+      #   assert(collection.includes?(actual), 'the message')
+      #
+      #   # good
+      #   assert_includes(collection, actual)
+      #   assert_includes(collection, actual, 'the message')
+      #
+      class AssertIncludes < Cop
+        MSG = 'Prefer using `assert_includes(%<arguments>s)` over ' \
+              '`assert(%<receiver>s)`.'
+
+        def_node_matcher :assert_with_includes, <<~PATTERN
+          (send nil? :assert $(send $_ :includes? $_) $...)
+        PATTERN
+
+        def on_send(node)
+          assert_with_includes(node) do
+            |first_receiver_arg, collection, actual, rest_receiver_arg|
+
+            message = rest_receiver_arg.first
+            arguments = node_arguments(collection, actual, message)
+            receiver = [first_receiver_arg.source, message&.source].compact.join(', ')
+
+            offense_message = format(MSG, arguments: arguments, receiver: receiver)
+
+            add_offense(node, message: offense_message)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            assert_with_includes(node) do
+              |_receiver, collection, actual, rest_receiver_arg|
+
+              message = rest_receiver_arg.first
+              replacement = node_arguments(collection, actual, message)
+              corrector.replace(node.loc.expression, "assert_includes(#{replacement})")
+            end
+          end
+        end
+
+        private
+
+        def node_arguments(collection, actual, message)
+          [collection.source, actual.source, message&.source].compact.join(', ')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/minitest_cops.rb
+++ b/lib/rubocop/cop/minitest_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'minitest/assert_nil'
+require_relative 'minitest/assert_includes'
 require_relative 'minitest/assert_truthy'
 require_relative 'minitest/refute_nil'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -1,6 +1,7 @@
 <!-- START_COP_LIST -->
 #### Department [Minitest](cops_minitest.md)
 
+* [Minitest/AssertIncludes](cops_minitest.md#minitestassertincludes)
 * [Minitest/AssertNil](cops_minitest.md#minitestassertnil)
 * [Minitest/AssertTruthy](cops_minitest.md#minitestasserttruthy)
 * [Minitest/RefuteNil](cops_minitest.md#minitestrefutenil)

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -1,5 +1,30 @@
 # Minitest
 
+## Minitest/AssertIncludes
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.2 | -
+
+Check if your test uses `assert_includes`
+instead of `assert(collection.includes?(actual))`.
+
+### Examples
+
+```ruby
+# bad
+assert(collection.includes?(actual))
+assert(collection.includes?(actual), 'the message')
+
+# good
+assert_includes(collection, actual)
+assert_includes(collection, actual, 'the message')
+```
+
+### References
+
+* [https://github.com/rubocop-hq/minitest-style-guide#assert-includes](https://github.com/rubocop-hq/minitest-style-guide#assert-includes)
+
 ## Minitest/AssertNil
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AssertIncludesTest < Minitest::Test
+  def setup
+    @cop = RuboCop::Cop::Minitest::AssertIncludes.new
+  end
+
+  def test_adds_offense_for_use_of_assert_collection_includes
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.includes?(actual))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual)` over `assert(collection.includes?(actual))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_includes(collection, actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_collection_includes_with_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.includes?(actual), 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, 'the message')` over `assert(collection.includes?(actual), 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_includes(collection, actual, 'the message')
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_collection_includes_with_variable_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          assert(collection.includes?(actual), message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, message)` over `assert(collection.includes?(actual), message)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          assert_includes(collection, actual, message)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_collection_includes_with_constant_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          assert(collection.includes?(actual), MESSAGE)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, MESSAGE)` over `assert(collection.includes?(actual), MESSAGE)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          assert_includes(collection, actual, MESSAGE)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_offend_if_using_assert_nil
+    assert_no_offenses(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_includes(collection, actual)
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
PR adds cops to enforce the use of `assert_includes` over `assert(collection.includes?(actual))`

Ref: https://github.com/rubocop-hq/minitest-style-guide#assert-includes