### PR TITLE
Added a cop to enforce assert_empty over assert(actual.empty?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#11](https://github.com/rubocop-hq/rubocop-minitest/pull/11): Add new `Minitest/RefuteNil` cop. ([@tejasbubane ][])
 * [#8](https://github.com/rubocop-hq/rubocop-minitest/pull/8): Add new `Minitest/AssertTruthy` cop. ([@abhaynikam ][])
 * [#9](https://github.com/rubocop-hq/rubocop-minitest/pull/9): Add new `Minitest/AssertIncludes` cop. ([@abhaynikam ][])
+* [#10](https://github.com/rubocop-hq/rubocop-minitest/pull/10): Add new `Minitest/AssertEmpty` cop. ([@abhaynikam ][])
 
 ## 0.1.0 (2019-09-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,12 @@ Minitest/AssertNil:
   Enabled: true
   VersionAdded: '0.1'
 
+Minitest/AssertEmpty:
+  Description: 'Check if your test uses `assert_empty` instead of `assert(actual.empty?)`.'
+  StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-empty'
+  Enabled: true
+  VersionAdded: '0.2'
+
 Minitest/AssertIncludes:
   Description: 'Check if your test uses `assert_includes` instead of `assert(collection.includes?(actual))`.'
   StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-includes'

--- a/lib/rubocop/cop/minitest/assert_empty.rb
+++ b/lib/rubocop/cop/minitest/assert_empty.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Minitest
+      # Check if your test uses `assert_empty` instead of `assert(actual.empty?)`.
+      #
+      # @example
+      #   # bad
+      #   assert(actual.empty?)
+      #   assert(actual.empty?, 'the message')
+      #
+      #   # good
+      #   assert_empty(actual)
+      #   assert_empty(actual, 'the message')
+      #
+      class AssertEmpty < Cop
+        MSG = 'Prefer using `assert_empty(%<arguments>s)` over ' \
+              '`assert(%<receiver>s)`.'
+
+        def_node_matcher :assert_with_empty, <<~PATTERN
+          (send nil? :assert $(send $_ :empty?) $...)
+        PATTERN
+
+        def on_send(node)
+          assert_with_empty(node) do |first_receiver_arg, actual, rest_receiver_arg|
+            message = rest_receiver_arg.first
+
+            arguments = [actual.source, message&.source].compact.join(', ')
+            receiver = [first_receiver_arg.source, message&.source].compact.join(', ')
+
+            offense_message = format(MSG, arguments: arguments, receiver: receiver)
+            add_offense(node, message: offense_message)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            assert_with_empty(node) do |_first_receiver_arg, actual, rest_receiver_arg|
+              message = rest_receiver_arg.first
+
+              replacement = [actual.source, message&.source].compact.join(', ')
+              corrector.replace(node.loc.expression, "assert_empty(#{replacement})")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/minitest_cops.rb
+++ b/lib/rubocop/cop/minitest_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'minitest/assert_empty'
 require_relative 'minitest/assert_nil'
 require_relative 'minitest/assert_includes'
 require_relative 'minitest/assert_truthy'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -1,6 +1,7 @@
 <!-- START_COP_LIST -->
 #### Department [Minitest](cops_minitest.md)
 
+* [Minitest/AssertEmpty](cops_minitest.md#minitestassertempty)
 * [Minitest/AssertIncludes](cops_minitest.md#minitestassertincludes)
 * [Minitest/AssertNil](cops_minitest.md#minitestassertnil)
 * [Minitest/AssertTruthy](cops_minitest.md#minitestasserttruthy)

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -1,5 +1,29 @@
 # Minitest
 
+## Minitest/AssertEmpty
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.2 | -
+
+Check if your test uses `assert_empty` instead of `assert(actual.empty?)`.
+
+### Examples
+
+```ruby
+# bad
+assert(actual.empty?)
+assert(actual.empty?, 'the message')
+
+# good
+assert_empty(actual)
+assert_empty(actual, 'the message')
+```
+
+### References
+
+* [https://github.com/rubocop-hq/minitest-style-guide#assert-empty](https://github.com/rubocop-hq/minitest-style-guide#assert-empty)
+
 ## Minitest/AssertIncludes
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/minitest/assert_empty_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AssertEmptyTest < Minitest::Test
+  def setup
+    @cop = RuboCop::Cop::Minitest::AssertEmpty.new
+  end
+
+  def test_adds_offense_for_use_of_assert_with_empty
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(somestuff.empty?)
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)` over `assert(somestuff.empty?)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_empty(somestuff)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_with_empty_and_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(somestuff.empty?, 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff, 'the message')` over `assert(somestuff.empty?, 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_empty(somestuff, 'the message')
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_with_empty_and_string_variable_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          assert(somestuff.empty?, message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff, message)` over `assert(somestuff.empty?, message)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          assert_empty(somestuff, message)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_assert_with_empty_and_a_constant_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          assert(somestuff.empty?, MESSAGE)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff, MESSAGE)` over `assert(somestuff.empty?, MESSAGE)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          assert_empty(somestuff, MESSAGE)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_offend_if_using_assert_empty
+    assert_no_offenses(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_empty(somestuff)
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
PR adds cops to enforce the use of `assert_empty` over `assert(actual.empty?)`

Ref: https://github.com/rubocop-hq/minitest-style-guide#assert-empty