### PR TITLE
Modify `Minitest/AssertTruthy` to check for `refute_equal`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Naming/PredicateName:
     - def_node_search
 
 Style/FormatStringToken:
+  Enabled: false
   # Because we parse a lot of source codes from strings. Percent arrays
   # look like unannotated format string tokens to this cop.
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#8](https://github.com/rubocop-hq/rubocop-minitest/pull/8): Add new `Minitest/AssertTruthy` cop. ([@abhaynikam ][])
 * [#9](https://github.com/rubocop-hq/rubocop-minitest/pull/9): Add new `Minitest/AssertIncludes` cop. ([@abhaynikam ][])
 * [#10](https://github.com/rubocop-hq/rubocop-minitest/pull/10): Add new `Minitest/AssertEmpty` cop. ([@abhaynikam ][])
+* [#12](https://github.com/rubocop-hq/rubocop-minitest/pull/12): Modify `Minitest/AssertTruthy` to check for `refute_equal`. ([@tejasbubane ][])
 
 ## 0.1.0 (2019-09-01)
 

--- a/lib/rubocop/cop/minitest/assert_truthy.rb
+++ b/lib/rubocop/cop/minitest/assert_truthy.rb
@@ -4,41 +4,58 @@ module RuboCop
   module Cop
     module Minitest
       # Check if your test uses `assert(actual)`
-      # instead of `assert_equal(true, actual)`.
+      # instead of `assert_equal(true, actual)` &
+      # `refute(actual)` instead of `refute_equal(true, actual)`
       #
       # @example
       #   # bad
       #   assert_equal(true, actual)
       #   assert_equal(true, actual, 'the message')
+      #   refute_equal(true, actual)
+      #   refute_equal(true, actual, 'the message')
       #
       #   # good
       #   assert(actual)
       #   assert(actual, 'the message')
+      #   refute(actual)
+      #   refute(actual, 'the message')
       #
       class AssertTruthy < Cop
-        MSG = 'Prefer using `assert(%<arguments>s)` over ' \
-              '`assert_equal(true, %<arguments>s)`.'
+        MSG = 'Prefer using `%{replacement}(%<arguments>s)` over ' \
+              '`%{assertion}(true, %<arguments>s)`.'
 
         def_node_matcher :assert_equal_with_truthy, <<~PATTERN
-          (send nil? :assert_equal true $_ $...)
+          (send nil? ${:assert_equal :refute_equal} true $_ $...)
         PATTERN
 
         def on_send(node)
-          assert_equal_with_truthy(node) do |actual, rest_receiver_arg|
-            message = rest_receiver_arg.first
+          assert_equal_with_truthy(node) do |assertion, actual, rest_args|
+            message = rest_args.first
 
             arguments = [actual.source, message&.source].compact.join(', ')
-
-            add_offense(node, message: format(MSG, arguments: arguments))
+            add_offense(node, message: message(assertion, arguments))
           end
         end
 
         def autocorrect(node)
           lambda do |corrector|
-            arguments = node.arguments.reject(&:true_type?)
-            replacement = arguments.map(&:source).join(', ')
-            corrector.replace(node.loc.expression, "assert(#{replacement})")
+            arguments = node.arguments
+                            .reject(&:true_type?)
+                            .map(&:source).join(', ')
+            corrected = "#{replacement(node.children[1])}(#{arguments})"
+            corrector.replace(node.loc.expression, corrected)
           end
+        end
+
+        private
+
+        def message(assertion, arguments)
+          format(MSG, assertion: assertion, replacement: replacement(assertion),
+                      arguments: arguments)
+        end
+
+        def replacement(method_name)
+          method_name == :assert_equal ? :assert : :refute
         end
       end
     end

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -80,7 +80,8 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.2 | -
 
 Check if your test uses `assert(actual)`
-instead of `assert_equal(true, actual)`.
+instead of `assert_equal(true, actual)` &
+`refute(actual)` instead of `refute_equal(true, actual)`
 
 ### Examples
 
@@ -88,10 +89,14 @@ instead of `assert_equal(true, actual)`.
 # bad
 assert_equal(true, actual)
 assert_equal(true, actual, 'the message')
+refute_equal(true, actual)
+refute_equal(true, actual, 'the message')
 
 # good
 assert(actual)
 assert(actual, 'the message')
+refute(actual)
+refute(actual, 'the message')
 ```
 
 ### References

--- a/test/rubocop/cop/minitest/assert_truthy_test.rb
+++ b/test/rubocop/cop/minitest/assert_truthy_test.rb
@@ -117,4 +117,116 @@ class AssertTruthyTest < Minitest::Test
       end
     RUBY
   end
+
+  # Refute
+  def test_adds_offense_for_use_of_refute_equal_true
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_equal(true, somestuff)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute(somestuff)` over `refute_equal(true, somestuff)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(somestuff)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_refute_equal_true_with_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_equal(true, somestuff, 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute(somestuff, 'the message')` over `refute_equal(true, somestuff, 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(somestuff, 'the message')
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_refute_equal_with_a_method_call
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_equal(true, obj.is_something?, 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute(obj.is_something?, 'the message')` over `refute_equal(true, obj.is_something?, 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(obj.is_something?, 'the message')
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_refute_equal_with_a_string_variable_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          refute_equal(true, somestuff, message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute(somestuff, message)` over `refute_equal(true, somestuff, message)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          message = 'the message'
+          refute(somestuff, message)
+        end
+      end
+    RUBY
+  end
+
+  def test_adds_offense_for_use_of_refute_equal_with_a_constant_in_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          refute_equal(true, somestuff, MESSAGE)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute(somestuff, MESSAGE)` over `refute_equal(true, somestuff, MESSAGE)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        MESSAGE = 'the message'
+
+        def test_do_something
+          refute(somestuff, MESSAGE)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_offend_if_using_refute
+    assert_no_offenses(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_somethingra
+          refute(somestuff)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Alternative to separate cop approach in https://github.com/rubocop-hq/rubocop-minitest/pull/11

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/