### PR TITLE
Fixed the test description typo from assert_nil -> assert_includes

### DIFF
--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -89,7 +89,7 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_does_not_register_offense_when_using_assert_nil_method
+  def test_does_not_register_offense_when_using_assert_includes_method
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something


### PR DESCRIPTION
Assert Include cop test description had a typo. Changed it from `assert_nil` -> `assert_includes`