### PR TITLE
Fixed typo for AssertIncludes cop. Changed includes -> include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#19](https://github.com/rubocop-hq/rubocop-minitest/pull/19): Fix a false negative for `Minitest/AssertIncludes` when using `include` method in arguments of `assert` method. ([@abhaynikam][])
+
 ## 0.2.1 (2019-09-24)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -15,7 +15,7 @@ Minitest/AssertEmpty:
   VersionAdded: '0.2'
 
 Minitest/AssertIncludes:
-  Description: 'Check if your test uses `assert_includes` instead of `assert(collection.includes?(actual))`.'
+  Description: 'Check if your test uses `assert_includes` instead of `assert(collection.include?(actual))`.'
   StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-includes'
   Enabled: true
   VersionAdded: '0.2'

--- a/lib/rubocop/cop/minitest/assert_includes.rb
+++ b/lib/rubocop/cop/minitest/assert_includes.rb
@@ -4,12 +4,12 @@ module RuboCop
   module Cop
     module Minitest
       # Check if your test uses `assert_includes`
-      # instead of `assert(collection.includes?(actual))`.
+      # instead of `assert(collection.include?(actual))`.
       #
       # @example
       #   # bad
-      #   assert(collection.includes?(actual))
-      #   assert(collection.includes?(actual), 'the message')
+      #   assert(collection.include?(actual))
+      #   assert(collection.include?(actual), 'the message')
       #
       #   # good
       #   assert_includes(collection, actual)
@@ -20,7 +20,7 @@ module RuboCop
               '`assert(%<receiver>s)`.'
 
         def_node_matcher :assert_with_includes, <<~PATTERN
-          (send nil? :assert $(send $_ :includes? $_) $...)
+          (send nil? :assert $(send $_ :include? $_) $...)
         PATTERN
 
         def on_send(node)

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -31,14 +31,14 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.2 | -
 
 Check if your test uses `assert_includes`
-instead of `assert(collection.includes?(actual))`.
+instead of `assert(collection.include?(actual))`.
 
 ### Examples
 
 ```ruby
 # bad
-assert(collection.includes?(actual))
-assert(collection.includes?(actual), 'the message')
+assert(collection.include?(actual))
+assert(collection.include?(actual), 'the message')
 
 # good
 assert_includes(collection, actual)

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -7,12 +7,12 @@ class AssertIncludesTest < Minitest::Test
     @cop = RuboCop::Cop::Minitest::AssertIncludes.new
   end
 
-  def test_registers_offense_when_using_assert_with_includes
+  def test_registers_offense_when_using_assert_with_include
     assert_offense(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(collection.includes?(actual))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual)` over `assert(collection.includes?(actual))`.
+          assert(collection.include?(actual))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual)` over `assert(collection.include?(actual))`.
         end
       end
     RUBY
@@ -26,12 +26,12 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_includes_and_message
+  def test_registers_offense_when_using_assert_with_include_and_message
     assert_offense(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(collection.includes?(actual), 'the message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, 'the message')` over `assert(collection.includes?(actual), 'the message')`.
+          assert(collection.include?(actual), 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, 'the message')` over `assert(collection.include?(actual), 'the message')`.
         end
       end
     RUBY
@@ -45,13 +45,13 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_includes_and_variable_message
+  def test_registers_offense_when_using_assert_with_include_and_variable_message
     assert_offense(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
           message = 'the message'
-          assert(collection.includes?(actual), message)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, message)` over `assert(collection.includes?(actual), message)`.
+          assert(collection.include?(actual), message)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, message)` over `assert(collection.include?(actual), message)`.
         end
       end
     RUBY
@@ -66,14 +66,14 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_includes_and_constant_message
+  def test_registers_offense_when_using_assert_with_include_and_constant_message
     assert_offense(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         MESSAGE = 'the message'
 
         def test_do_something
-          assert(collection.includes?(actual), MESSAGE)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, MESSAGE)` over `assert(collection.includes?(actual), MESSAGE)`.
+          assert(collection.include?(actual), MESSAGE)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, MESSAGE)` over `assert(collection.include?(actual), MESSAGE)`.
         end
       end
     RUBY


### PR DESCRIPTION
This PR fixes the typo for AssertIncludes cop. Changes `collection.includes` -> `collection.include` at all places.