### PR TITLE
Renamed the assertion argument to object from actual

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -9,13 +9,13 @@ Minitest/AssertNil:
   VersionAdded: '0.1'
 
 Minitest/AssertEmpty:
-  Description: 'This cop enforces the test to use `assert_empty` instead of using `assert(actual.empty?)`.'
+  Description: 'This cop enforces the test to use `assert_empty` instead of using `assert(object.empty?)`.'
   StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-empty'
   Enabled: true
   VersionAdded: '0.2'
 
 Minitest/AssertIncludes:
-  Description: 'This cop enforces the test to use `assert_includes` instead of using `assert(collection.include?(actual))`.'
+  Description: 'This cop enforces the test to use `assert_includes` instead of using `assert(collection.include?(object))`.'
   StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-includes'
   Enabled: true
   VersionAdded: '0.2'

--- a/lib/rubocop/cop/minitest/assert_empty.rb
+++ b/lib/rubocop/cop/minitest/assert_empty.rb
@@ -4,16 +4,16 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the test to use `assert_empty`
-      # instead of using `assert(actual.empty?)`.
+      # instead of using `assert(object.empty?)`.
       #
       # @example
       #   # bad
-      #   assert(actual.empty?)
-      #   assert(actual.empty?, 'the message')
+      #   assert(object.empty?)
+      #   assert(object.empty?, 'the message')
       #
       #   # good
-      #   assert_empty(actual)
-      #   assert_empty(actual, 'the message')
+      #   assert_empty(object)
+      #   assert_empty(object, 'the message')
       #
       class AssertEmpty < Cop
         MSG = 'Prefer using `assert_empty(%<arguments>s)` over ' \

--- a/lib/rubocop/cop/minitest/assert_includes.rb
+++ b/lib/rubocop/cop/minitest/assert_includes.rb
@@ -4,16 +4,16 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the test to use `assert_includes`
-      # instead of using `assert(collection.include?(actual))`.
+      # instead of using `assert(collection.include?(object))`.
       #
       # @example
       #   # bad
-      #   assert(collection.include?(actual))
-      #   assert(collection.include?(actual), 'the message')
+      #   assert(collection.include?(object))
+      #   assert(collection.include?(object), 'the message')
       #
       #   # good
-      #   assert_includes(collection, actual)
-      #   assert_includes(collection, actual, 'the message')
+      #   assert_includes(collection, object)
+      #   assert_includes(collection, object, 'the message')
       #
       class AssertIncludes < Cop
         MSG = 'Prefer using `assert_includes(%<arguments>s)` over ' \

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -7,18 +7,18 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.2 | -
 
 This cop enforces the test to use `assert_empty`
-instead of using `assert(actual.empty?)`.
+instead of using `assert(object.empty?)`.
 
 ### Examples
 
 ```ruby
 # bad
-assert(actual.empty?)
-assert(actual.empty?, 'the message')
+assert(object.empty?)
+assert(object.empty?, 'the message')
 
 # good
-assert_empty(actual)
-assert_empty(actual, 'the message')
+assert_empty(object)
+assert_empty(object, 'the message')
 ```
 
 ### References
@@ -32,18 +32,18 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.2 | -
 
 This cop enforces the test to use `assert_includes`
-instead of using `assert(collection.include?(actual))`.
+instead of using `assert(collection.include?(object))`.
 
 ### Examples
 
 ```ruby
 # bad
-assert(collection.include?(actual))
-assert(collection.include?(actual), 'the message')
+assert(collection.include?(object))
+assert(collection.include?(object), 'the message')
 
 # good
-assert_includes(collection, actual)
-assert_includes(collection, actual, 'the message')
+assert_includes(collection, object)
+assert_includes(collection, object, 'the message')
 ```
 
 ### References

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -11,8 +11,8 @@ class AssertIncludesTest < Minitest::Test
     assert_offense(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(collection.include?(actual))
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual)` over `assert(collection.include?(actual))`.
+          assert(collection.include?(object))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)` over `assert(collection.include?(object))`.
         end
       end
     RUBY
@@ -20,7 +20,7 @@ class AssertIncludesTest < Minitest::Test
     assert_correction(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
-          assert_includes(collection, actual)
+          assert_includes(collection, object)
         end
       end
     RUBY
@@ -30,8 +30,8 @@ class AssertIncludesTest < Minitest::Test
     assert_offense(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(collection.include?(actual), 'the message')
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, 'the message')` over `assert(collection.include?(actual), 'the message')`.
+          assert(collection.include?(object), 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object, 'the message')` over `assert(collection.include?(object), 'the message')`.
         end
       end
     RUBY
@@ -39,7 +39,7 @@ class AssertIncludesTest < Minitest::Test
     assert_correction(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
-          assert_includes(collection, actual, 'the message')
+          assert_includes(collection, object, 'the message')
         end
       end
     RUBY
@@ -49,7 +49,7 @@ class AssertIncludesTest < Minitest::Test
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test
         def test_do_something
-          assert_includes(collection, actual)
+          assert_includes(collection, object)
         end
       end
     RUBY


### PR DESCRIPTION
As per @bbatsov comment, renamed the argument where no expectation is present to `object` from `actual`. 

Ref: https://github.com/rubocop-hq/rubocop-minitest/pull/20#discussion_r331858962