### PR TITLE
Removed redundant test cases added for checking constant and variables messages to an assertion

### DIFF
--- a/test/rubocop/cop/minitest/assert_empty_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_test.rb
@@ -45,50 +45,6 @@ class AssertEmptyTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_empty_and_variable_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert(somestuff.empty?, message)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff, message)` over `assert(somestuff.empty?, message)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert_empty(somestuff, message)
-        end
-      end
-    RUBY
-  end
-
-  def test_registers_offense_when_using_assert_with_empty_and_constant_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert(somestuff.empty?, MESSAGE)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff, MESSAGE)` over `assert(somestuff.empty?, MESSAGE)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert_empty(somestuff, MESSAGE)
-        end
-      end
-    RUBY
-  end
-
   def test_does_not_register_offense_when_using_assert_empty_method
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -45,50 +45,6 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_with_include_and_variable_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert(collection.include?(actual), message)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, message)` over `assert(collection.include?(actual), message)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert_includes(collection, actual, message)
-        end
-      end
-    RUBY
-  end
-
-  def test_registers_offense_when_using_assert_with_include_and_constant_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert(collection.include?(actual), MESSAGE)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, actual, MESSAGE)` over `assert(collection.include?(actual), MESSAGE)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert_includes(collection, actual, MESSAGE)
-        end
-      end
-    RUBY
-  end
-
   def test_does_not_register_offense_when_using_assert_includes_method
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_nil_test.rb
+++ b/test/rubocop/cop/minitest/assert_nil_test.rb
@@ -64,50 +64,6 @@ class AssertNilTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_equal_with_variable_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert_equal(nil, somestuff, message)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff, message)` over `assert_equal(nil, somestuff, message)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert_nil(somestuff, message)
-        end
-      end
-    RUBY
-  end
-
-  def test_registers_offense_when_using_assert_equal_with_constant_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert_equal(nil, somestuff, MESSAGE)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_nil(somestuff, MESSAGE)` over `assert_equal(nil, somestuff, MESSAGE)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert_nil(somestuff, MESSAGE)
-        end
-      end
-    RUBY
-  end
-
   def test_does_not_register_offense_when_using_assert_nil_method
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/assert_truthy_test.rb
+++ b/test/rubocop/cop/minitest/assert_truthy_test.rb
@@ -64,50 +64,6 @@ class AssertTruthyTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_assert_equal_with_variable_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert_equal(true, somestuff, message)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert(somestuff, message)` over `assert_equal(true, somestuff, message)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          assert(somestuff, message)
-        end
-      end
-    RUBY
-  end
-
-  def test_registers_offense_when_using_assert_equal_with_constant_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert_equal(true, somestuff, MESSAGE)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert(somestuff, MESSAGE)` over `assert_equal(true, somestuff, MESSAGE)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          assert(somestuff, MESSAGE)
-        end
-      end
-    RUBY
-  end
-
   def test_does_not_register_offense_when_using_assert_method
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_nil_test.rb
+++ b/test/rubocop/cop/minitest/refute_nil_test.rb
@@ -64,50 +64,6 @@ class RefuteNilTest < Minitest::Test
     RUBY
   end
 
-  def test_registers_offense_when_using_refute_equal_with_variable_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          refute_equal(nil, somestuff, message)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff, message)` over `refute_equal(nil, somestuff, message)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        def test_do_something
-          message = 'the message'
-          refute_nil(somestuff, message)
-        end
-      end
-    RUBY
-  end
-
-  def test_registers_offense_when_using_refute_equal_with_constant_message
-    assert_offense(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          refute_equal(nil, somestuff, MESSAGE)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_nil(somestuff, MESSAGE)` over `refute_equal(nil, somestuff, MESSAGE)`.
-        end
-      end
-    RUBY
-
-    assert_correction(<<~RUBY, @cop)
-      class FooTest < Minitest::Test
-        MESSAGE = 'the message'
-
-        def test_do_something
-          refute_nil(somestuff, MESSAGE)
-        end
-      end
-    RUBY
-  end
-
   def test_does_not_register_offense_when_using_refute_nil_method
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test


### PR DESCRIPTION
This PR removes the redundant test cases added for constant and variables message argument test cases for all the assertion. 

Refer the comment by @bbatsov for more details: https://github.com/rubocop-hq/rubocop-minitest/pull/20#discussion_r331735949