### PR TITLE
Fix English typo in the class documentation

### DIFF
--- a/lib/rubocop/cop/minitest/refute_equal.rb
+++ b/lib/rubocop/cop/minitest/refute_equal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Minitest
-      # This cop enforces the usages of `refute_equal(expected, object)`
+      # This cop enforces the use of `refute_equal(expected, object)`
       # over `assert_equal(expected != actual)` or `assert(! expected -= actual)`.
       #
       # @example

--- a/lib/rubocop/cop/minitest/refute_false.rb
+++ b/lib/rubocop/cop/minitest/refute_false.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Minitest
-      # This cop enforces the usages of `refute(object)`
+      # This cop enforces the use of `refute(object)`
       # over `assert_equal(false, object)`.
       #
       # @example

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -131,7 +131,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.3 | -
 
-This cop enforces the usages of `refute_equal(expected, object)`
+This cop enforces the use of `refute_equal(expected, object)`
 over `assert_equal(expected != actual)` or `assert(! expected -= actual)`.
 
 ### Examples
@@ -155,7 +155,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | Yes  | 0.3 | -
 
-This cop enforces the usages of `refute(object)`
+This cop enforces the use of `refute(object)`
 over `assert_equal(false, object)`.
 
 ### Examples


### PR DESCRIPTION
Hey folks 👋

I think we have a english typo in refute_equal and refute_false class
documentation. Instead of `enforces the usages` it should be `enforces
the use`.