### PR TITLE
Add release task and release notes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
+gem 'bump', require: false
 gem 'rake'
 gem 'rubocop', github: 'rubocop-hq/rubocop'
 gem 'rubocop-performance', '~> 1.4.0'

--- a/relnotes/v0.1.0.md
+++ b/relnotes/v0.1.0.md
@@ -1,0 +1,7 @@
+### New features
+
+* Create RuboCop Minitest gem. ([@koic][])
+* [#6](https://github.com/rubocop-hq/rubocop-minitest/pull/6): Add new `Minitest/AssertNil` cop. ([@duduribeiro ][])
+
+[@koic]: https://github.com/koic
+[@duduribeiro]: https://github.com/duduribeiro

--- a/relnotes/v0.2.0.md
+++ b/relnotes/v0.2.0.md
@@ -1,0 +1,9 @@
+### New features
+
+* [#11](https://github.com/rubocop-hq/rubocop-minitest/pull/11): Add new `Minitest/RefuteNil` cop. ([@tejasbubane ][])
+* [#8](https://github.com/rubocop-hq/rubocop-minitest/pull/8): Add new `Minitest/AssertTruthy` cop. ([@abhaynikam ][])
+* [#9](https://github.com/rubocop-hq/rubocop-minitest/pull/9): Add new `Minitest/AssertIncludes` cop. ([@abhaynikam ][])
+* [#10](https://github.com/rubocop-hq/rubocop-minitest/pull/10): Add new `Minitest/AssertEmpty` cop. ([@abhaynikam ][])
+
+[@tejasbubane]: https://github.com/tejasbubane
+[@abhaynikam]: https://github.com/abhaynikam

--- a/relnotes/v0.2.1.md
+++ b/relnotes/v0.2.1.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+ * [#13](https://github.com/rubocop-hq/rubocop-minitest/issues/13): Fix the execution target specified in `Include` parameter. ([@koic][])
+
+ [@koic]: https://github.com/koic

--- a/relnotes/v0.3.0.md
+++ b/relnotes/v0.3.0.md
@@ -1,0 +1,16 @@
+## 0.3.0 (2019-10-13)
+
+### New features
+
+* [#15](https://github.com/rubocop-hq/rubocop-minitest/pull/15): Add new `Minitest/RefuteIncludes` cop. ([@abhaynikam][])
+* [#18](https://github.com/rubocop-hq/rubocop-minitest/pull/18): Add new `Minitest/RefuteFalse` cop. ([@duduribeiro][])
+* [#20](https://github.com/rubocop-hq/rubocop-minitest/pull/20): Add new `Minitest/RefuteEmpty` cop. ([@abhaynikam][])
+* [#21](https://github.com/rubocop-hq/rubocop-minitest/pull/21): Add new `Minitest/RefuteEqual` cop. ([@duduribeiro][])
+* [#27](https://github.com/rubocop-hq/rubocop-minitest/pull/27): Add new `Minitest/AssertRespondTo` cop. ([@duduribeiro][])
+
+### Bug fixes
+
+* [#19](https://github.com/rubocop-hq/rubocop-minitest/pull/19): Fix a false negative for `Minitest/AssertIncludes` when using `include` method in arguments of `assert` method. ([@abhaynikam][])
+
+[@abhaynikam]: https://github.com/abhaynikam
+[@duduribeiro]: https://github.com/duduribeiro

--- a/tasks/cut_release.rake
+++ b/tasks/cut_release.rake
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'bump'
+
+namespace :cut_release do
+  %w[major minor patch pre].each do |release_type|
+    desc "Cut a new #{release_type} release, create release notes " \
+         'and update documents.'
+    task release_type do
+      run(release_type)
+    end
+  end
+
+  def add_header_to_changelog(version)
+    changelog = File.read('CHANGELOG.md')
+    head, tail = changelog.split("## master (unreleased)\n\n", 2)
+
+    File.open('CHANGELOG.md', 'w') do |f|
+      f << head
+      f << "## master (unreleased)\n\n"
+      f << "## #{version} (#{Time.now.strftime('%F')})\n\n"
+      f << tail
+    end
+  end
+
+  def create_release_notes(version)
+    release_notes = new_version_changes.strip
+    contributor_links = user_links(release_notes)
+
+    File.open("relnotes/v#{version}.md", 'w') do |file|
+      file << release_notes
+      file << "\n\n"
+      file << contributor_links
+      file << "\n"
+    end
+  end
+
+  def new_version_changes
+    changelog = File.read('CHANGELOG.md')
+    _, _, new_changes, _older_changes = changelog.split(/^## .*$/, 4)
+    new_changes
+  end
+
+  def user_links(text)
+    names = text.scan(/\[@(\S+)\]\[\]/).map(&:first).uniq
+    names.map { |name| "[@#{name}]: https://github.com/#{name}" }
+         .join("\n")
+  end
+
+  def run(release_type)
+    old_version = Bump::Bump.current
+    Bump::Bump.run(release_type, commit: false, bundle: false, tag: false)
+    new_version = Bump::Bump.current
+
+    add_header_to_changelog(new_version)
+    create_release_notes(new_version)
+
+    puts "Changed version from #{old_version} to #{new_version}."
+  end
+end


### PR DESCRIPTION
This PR adds the following rake tasks.

```console
% rake -T | grep cut_release
rake cut_release:major                    # Cut a new major release,
create release notes and update documents
rake cut_release:minor                    # Cut a new minor release,
create release notes and update documents
rake cut_release:patch                    # Cut a new patch release,
create release notes and update documents
rake cut_release:pre                      # Cut a new pre release,
create release notes and update documents
```

And the release notes from v0.1.0 to v0.3.0 already released will be added.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
