### PR TITLE
Typo fix in documentation of refute_equal

### DIFF
--- a/lib/rubocop/cop/minitest/refute_equal.rb
+++ b/lib/rubocop/cop/minitest/refute_equal.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the use of `refute_equal(expected, object)`
-      # over `assert_equal(expected != actual)` or `assert(! expected -= actual)`.
+      # over `assert_equal(expected != actual)` or `assert(! expected == actual)`.
       #
       # @example
       #   # bad

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -157,7 +157,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 Enabled | Yes | Yes  | 0.3 | -
 
 This cop enforces the use of `refute_equal(expected, object)`
-over `assert_equal(expected != actual)` or `assert(! expected -= actual)`.
+over `assert_equal(expected != actual)` or `assert(! expected == actual)`.
 
 ### Examples
 


### PR DESCRIPTION
Pretty trivial change

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
