### PR TITLE
Minitest/AssertEqual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#29](https://github.com/rubocop-hq/rubocop-minitest/pull/29): Add new `Minitest/RefuteRespondTo` cop.  ([@herwinw][])
+* [#31](https://github.com/rubocop-hq/rubocop-minitest/pull/31): Add new `Minitest/AssertEqual` cop. ([@herwinw][])
 
 ## 0.3.0 (2019-10-13)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -14,6 +14,12 @@ Minitest/AssertEmpty:
   Enabled: true
   VersionAdded: '0.2'
 
+Minitest/AssertEqual:
+  Description: 'This cop enforces the test to use `assert_equal` instead of using `assert(expected == actual)`.'
+  StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-equal-arguments-order'
+  Enabled: true
+  VersionAdded: '0.4'
+
 Minitest/AssertIncludes:
   Description: 'This cop enforces the test to use `assert_includes` instead of using `assert(collection.include?(object))`.'
   StyleGuide: 'https://github.com/rubocop-hq/minitest-style-guide#assert-includes'

--- a/lib/rubocop/cop/minitest/assert_equal.rb
+++ b/lib/rubocop/cop/minitest/assert_equal.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Minitest
+      # This cop enforces the use of `assert_equal(expected, actual)`
+      # over `assert(expected == actual)`.
+      #
+      # @example
+      #   # bad
+      #   assert("rubocop-minitest" == actual)
+      #
+      #   # good
+      #   assert_equal("rubocop-minitest", actual)
+      #
+      class AssertEqual < Cop
+        MSG = 'Prefer using `assert_equal(%<preferred>s)` over ' \
+              '`assert(%<over>s)`.'
+
+        def_node_matcher :assert_equal, <<~PATTERN
+          (send nil? :assert $(send $_ :== $_) $...)
+        PATTERN
+
+        def on_send(node)
+          assert_equal(node) do
+            |first_receiver_arg, expected, actual, rest_receiver_arg|
+
+            message = rest_receiver_arg.first
+            preferred = [expected.source, actual.source, message&.source]
+                        .compact.join(', ')
+            over = [first_receiver_arg.source, message&.source].compact.join(', ')
+
+            offense_message = format(MSG, preferred: preferred, over: over)
+
+            add_offense(node, message: offense_message)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            assert_equal(node) do |_receiver, expected, actual, rest_receiver_arg|
+              message = rest_receiver_arg.first
+              replacement = node_arguments(expected, actual, message)
+              corrector.replace(node.loc.expression, "assert_equal(#{replacement})")
+            end
+          end
+        end
+
+        private
+
+        def node_arguments(expected, actual, message)
+          [expected.source, actual.source, message&.source].compact.join(', ')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/minitest_cops.rb
+++ b/lib/rubocop/cop/minitest_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'minitest/assert_empty'
+require_relative 'minitest/assert_equal'
 require_relative 'minitest/assert_nil'
 require_relative 'minitest/assert_includes'
 require_relative 'minitest/assert_respond_to'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -2,6 +2,7 @@
 #### Department [Minitest](cops_minitest.md)
 
 * [Minitest/AssertEmpty](cops_minitest.md#minitestassertempty)
+* [Minitest/AssertEqual](cops_minitest.md#minitestassertequal)
 * [Minitest/AssertIncludes](cops_minitest.md#minitestassertincludes)
 * [Minitest/AssertNil](cops_minitest.md#minitestassertnil)
 * [Minitest/AssertRespondTo](cops_minitest.md#minitestassertrespondto)

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -25,6 +25,29 @@ assert_empty(object, 'the message')
 
 * [https://github.com/rubocop-hq/minitest-style-guide#assert-empty](https://github.com/rubocop-hq/minitest-style-guide#assert-empty)
 
+## Minitest/AssertEqual
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 0.4 | -
+
+This cop enforces the use of `assert_equal(expected, actual)`
+over `assert(expected == actual)`.
+
+### Examples
+
+```ruby
+# bad
+assert("rubocop-minitest" == actual)
+
+# good
+assert_equal("rubocop-minitest", actual)
+```
+
+### References
+
+* [https://github.com/rubocop-hq/minitest-style-guide#assert-equal-arguments-order](https://github.com/rubocop-hq/minitest-style-guide#assert-equal-arguments-order)
+
 ## Minitest/AssertIncludes
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged

--- a/test/rubocop/cop/minitest/assert_equal_test.rb
+++ b/test/rubocop/cop/minitest/assert_equal_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AssertEqualTest < Minitest::Test
+  def setup
+    @cop = RuboCop::Cop::Minitest::AssertEqual.new
+  end
+
+  def test_registers_offense_when_using_assert_equal_operator_with_string
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert('rubocop-minitest' == actual)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal('rubocop-minitest', actual)` over `assert('rubocop-minitest' == actual)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_equal_operator_with_object
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(expected == actual)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal(expected, actual)` over `assert(expected == actual)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(expected, actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_equal_operator_with_method_call
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(obj.expected == other_obj.actual)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal(obj.expected, other_obj.actual)` over `assert(obj.expected == other_obj.actual)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(obj.expected, other_obj.actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_equal_operator_with_the_message
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert('rubocop-minitest' == actual, 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal('rubocop-minitest', actual, 'the message')` over `assert('rubocop-minitest' == actual, 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal('rubocop-minitest', actual, 'the message')
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_assert_equal
+    assert_no_offenses(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal('rubocop-minitest', actual)
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Prefer `assert_equal` over `assert(expected == actual)`
(I'll leave the updates to the changelog until the merge of #29, to save myself some merge conflicts. The remainder of the code can be reviewed)

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
