### PR TITLE
[Fix #25] Add `Enabled: true` to `Minitest` department config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#29](https://github.com/rubocop-hq/rubocop-minitest/pull/29): Add new `Minitest/RefuteRespondTo` cop.  ([@herwinw][])
 * [#31](https://github.com/rubocop-hq/rubocop-minitest/pull/31): Add new `Minitest/AssertEqual` cop. ([@herwinw][])
 
+### Bug fixes
+
+* [#25](https://github.com/rubocop-hq/rubocop-minitest/issues/25): Add `Enabled: true` to `Minitest` department config to suppress `Warning: Minitest does not support Enabled parameter`. ([@koic][])
+
 ## 0.3.0 (2019-10-13)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,5 @@
 Minitest:
+  Enabled: true
   Include:
     - '**/test/**/*'
 


### PR DESCRIPTION
Fixes #25.

This PR adds `Enabled: true` to `Minitest` department config.
It resolves the following warning:

```yaml
# .rubocop.yml
require: rubocop-minitest

AllCops:
  DisabledByDefault: true

Minitest:
  Enabled: true
```

```console
% bundle exec rubocop
Warning: Minitest does not support Enabled parameter.

Supported parameters are:

  - Include
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
