### PR TITLE
[Fix #39] Fix an incorrect autocorrect for `Minitest/AssertRespondTo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#39](https://github.com/rubocop-hq/rubocop-minitest/issues/39): Fix an incorrect autocorrect for `Minitest/AssertRespondTo` and `Minitest/RefuteRespondTo` when using assertion method calling `respond_to` with receiver omitted. ([@koic][])
+
 ## 0.4.0 (2019-11-07)
 
 ### New features

--- a/lib/rubocop/cop/minitest/assert_respond_to.rb
+++ b/lib/rubocop/cop/minitest/assert_respond_to.rb
@@ -10,10 +10,12 @@ module RuboCop
       #   # bad
       #   assert(object.respond_to?(:some_method))
       #   assert(object.respond_to?(:some_method), 'the message')
+      #   assert(respond_to?(:some_method))
       #
       #   # good
       #   assert_respond_to(object, :some_method)
       #   assert_respond_to(object, :some_method, 'the message')
+      #   assert_respond_to(self, some_method)
       #
       class AssertRespondTo < Cop
         MSG = 'Prefer using `assert_respond_to(%<preferred>s)` over ' \
@@ -26,9 +28,8 @@ module RuboCop
         def on_send(node)
           assert_with_respond_to(node) do |over, object, method, rest_args|
             custom_message = rest_args.first
-            preferred = [object, method, custom_message]
-                        .compact.map(&:source).join(', ')
-            over      = [over, custom_message].compact.map(&:source).join(', ')
+            preferred = build_preferred_arguments(object, method, custom_message)
+            over = [over, custom_message].compact.map(&:source).join(', ')
             message = format(MSG, preferred: preferred, over: over)
             add_offense(node, message: message)
           end
@@ -38,12 +39,19 @@ module RuboCop
           lambda do |corrector|
             assert_with_respond_to(node) do |_, object, method, rest_args|
               custom_message = rest_args.first
-              preferred = [object, method, custom_message]
-                          .compact.map(&:source).join(', ')
+              preferred = build_preferred_arguments(object, method, custom_message)
               replacement = "assert_respond_to(#{preferred})"
               corrector.replace(node.loc.expression, replacement)
             end
           end
+        end
+
+        private
+
+        def build_preferred_arguments(receiver, method, message)
+          receiver = receiver ? receiver.source : 'self'
+
+          [receiver, method.source, message&.source].compact.join(', ')
         end
       end
     end

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -138,10 +138,12 @@ over `assert(object.respond_to?(:some_method))`.
 # bad
 assert(object.respond_to?(:some_method))
 assert(object.respond_to?(:some_method), 'the message')
+assert(respond_to?(:some_method))
 
 # good
 assert_respond_to(object, :some_method)
 assert_respond_to(object, :some_method, 'the message')
+assert_respond_to(self, some_method)
 ```
 
 ### References
@@ -337,10 +339,12 @@ over `refute(object.respond_to?(:some_method))`.
 # bad
 refute(object.respond_to?(:some_method))
 refute(object.respond_to?(:some_method), 'the message')
+refute(respond_to?(:some_method))
 
 # good
 refute_respond_to(object, :some_method)
 refute_respond_to(object, :some_method, 'the message')
+refute_respond_to(self, :some_method)
 ```
 
 ### References

--- a/test/rubocop/cop/minitest/assert_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/assert_respond_to_test.rb
@@ -45,6 +45,25 @@ class AssertRespondToTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_calling_respond_to_with_receiver_omitted
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(respond_to?(:some_method))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_respond_to(self, :some_method)` over `assert(respond_to?(:some_method))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_respond_to(self, :some_method)
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_respond_to
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/refute_respond_to_test.rb
@@ -45,6 +45,25 @@ class RefuteRespondToTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_calling_respond_to_with_receiver_omitted
+    assert_offense(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(respond_to?(:some_method))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_respond_to(self, :some_method)` over `refute(respond_to?(:some_method))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY, @cop)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_respond_to(self, :some_method)
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_respond_to
     assert_no_offenses(<<~RUBY, @cop)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Fixes #39.

This PR fixes an incorrect autocorrect for `Minitest/AssertRespondTo` and `Minitest/RefuteRespondTo` when using assertion method calling `respond_to` with receiver omitted.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
