### PR TITLE
Workaround for broke CI with YARD 0.9.20 when using Ruby 2.7.0-dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,7 @@ gem 'bump', require: false
 gem 'rake'
 gem 'rubocop', github: 'rubocop-hq/rubocop'
 gem 'rubocop-performance', '~> 1.5.0'
-gem 'yard', '~> 0.9'
+# Workaround for YARD 0.9.20 or lower.
+# It specifies `github` until the release that includes the following changes:
+# https://github.com/lsegal/yard/pull/1290
+gem 'yard', github: 'lsegal/yard', ref: '10a2e5b'


### PR DESCRIPTION
This PR solves the following "The manual directory is out of sync" error when using Ruby 2.7.0-dev.

```console
% ruby -v
ruby 2.7.0dev (2019-12-03T05:51:14Z master e42d9d8df8) [x86_64-darwin17]
% CI=true bundle exec rake

(snip)

The manual directory is out of sync. Run `rake
generate_cops_documentation` and commit the results.
```

https://circleci.com/gh/rubocop-hq/rubocop-minitest/968

This issue will be resolved with the release of YARD 0.9.21 or higher, which includes the following changes:
https://github.com/lsegal/yard/pull/1290

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
