### PR TITLE
Revert "Workaround for broke CI with YARD 0.9.20 when using Ruby 2.7.0-dev"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,4 @@ gem 'bump', require: false
 gem 'rake'
 gem 'rubocop', github: 'rubocop-hq/rubocop'
 gem 'rubocop-performance', '~> 1.5.0'
-# Workaround for YARD 0.9.20 or lower.
-# It specifies `github` until the release that includes the following changes:
-# https://github.com/lsegal/yard/pull/1290
-gem 'yard', github: 'lsegal/yard', ref: '10a2e5b'
+gem 'yard', '~> 0.9'


### PR DESCRIPTION
This reverts commit f170cc5d74ff8f743f6de06c2a3fe0cf2af8dc57.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
