### PR TITLE
Enable to work `Exclude` in AllCops section

### DIFF
--- a/lib/rubocop/minitest/inject.rb
+++ b/lib/rubocop/minitest/inject.rb
@@ -8,7 +8,7 @@ module RuboCop
       def self.defaults!
         path = CONFIG_DEFAULT.to_s
         hash = ConfigLoader.send(:load_yaml_configuration, path)
-        config = Config.new(hash, path)
+        config = Config.new(hash, path).tap(&:make_excludes_absolute)
         puts "configuration from #{path}" if ConfigLoader.debug?
         config = ConfigLoader.merge_with_default(config, path)
         ConfigLoader.instance_variable_set(:@default_configuration, config)


### PR DESCRIPTION
Follow up of https://github.com/rubocop-hq/rubocop-extension-generator/pull/8.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
