### PR TITLE
Make `Minitest/RefuteFalse` cop aware of `assert(!test)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#52](https://github.com/rubocop-hq/rubocop-minitest/issues/52): Make `Minitest/RefuteFalse` cop aware of `assert(!test)`. ([@koic][])
+
 ## 0.6.0 (2020-02-07)
 
 ### New features

--- a/manual/cops_minitest.md
+++ b/manual/cops_minitest.md
@@ -285,6 +285,9 @@ over `assert_equal(false, object)`.
 assert_equal(false, actual)
 assert_equal(false, actual, 'the message')
 
+assert(!test)
+assert(!test, 'the message')
+
 # good
 refute(actual)
 refute(actual, 'the message')

--- a/test/rubocop/cop/minitest/refute_false_test.rb
+++ b/test/rubocop/cop/minitest/refute_false_test.rb
@@ -85,6 +85,44 @@ class RefuteFalseTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_test_condition
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(!test)
+          ^^^^^^^^^^^^^ Prefer using `refute(test)` over `assert(!test)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(test)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_with_bang_test_and_message
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(!test, 'the message')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute(test, 'the message')` over `assert(!test, 'the message')`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(test, 'the message')
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_refute_method
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
This PR makes `Minitest/RefuteFalse` cop aware of `assert(!test)`.
It solves one of the following issue #52.
https://github.com/rubocop-hq/rubocop-minitest/issues/52#issuecomment-584031108.

The issue #52 has another `Minitest/RefuteIncludes` cop's false negative, which will be resolved in another PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
