### PR TITLE
[Fix #52] Fix a false negative for `Minitest/RefuteIncludes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#52](https://github.com/rubocop-hq/rubocop-minitest/issues/52): Make `Minitest/RefuteFalse` cop aware of `assert(!test)`. ([@koic][])
+* [#52](https://github.com/rubocop-hq/rubocop-minitest/issues/52): Fix a false negative for `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` when an argument is enclosed in redundant parentheses. ([@koic][])
 
 ## 0.6.0 (2020-02-07)
 

--- a/lib/rubocop/cop/minitest/assert_includes.rb
+++ b/lib/rubocop/cop/minitest/assert_includes.rb
@@ -16,45 +16,9 @@ module RuboCop
       #   assert_includes(collection, object, 'the message')
       #
       class AssertIncludes < Cop
-        include ArgumentRangeHelper
+        extend IncludesCopRule
 
-        MSG = 'Prefer using `assert_includes(%<arguments>s)` over ' \
-              '`assert(%<receiver>s)`.'
-
-        def_node_matcher :assert_with_includes, <<~PATTERN
-          (send nil? :assert $(send $_ :include? $_) $...)
-        PATTERN
-
-        def on_send(node)
-          assert_with_includes(node) do
-            |first_receiver_arg, collection, actual, rest_receiver_arg|
-
-            message = rest_receiver_arg.first
-            arguments = node_arguments(collection, actual, message)
-            receiver = [first_receiver_arg.source, message&.source].compact.join(', ')
-
-            offense_message = format(MSG, arguments: arguments, receiver: receiver)
-
-            add_offense(node, message: offense_message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            assert_with_includes(node) do |_, collection, actual|
-              corrector.replace(node.loc.selector, 'assert_includes')
-
-              replacement = [collection, actual].map(&:source).join(', ')
-              corrector.replace(first_argument_range(node), replacement)
-            end
-          end
-        end
-
-        private
-
-        def node_arguments(collection, actual, message)
-          [collection.source, actual.source, message&.source].compact.join(', ')
-        end
+        rule target_method: :assert, prefer_method: :assert_includes
       end
     end
   end

--- a/lib/rubocop/cop/minitest_cops.rb
+++ b/lib/rubocop/cop/minitest_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'mixin/argument_range_helper'
+require_relative 'mixin/includes_cop_rule'
 require_relative 'minitest/assert_empty'
 require_relative 'minitest/assert_empty_literal'
 require_relative 'minitest/assert_equal'

--- a/lib/rubocop/cop/mixin/includes_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/includes_cop_rule.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Define the rule for `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` cops.
+    module IncludesCopRule
+      def rule(target_method:, prefer_method:)
+        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          include ArgumentRangeHelper
+
+          MSG = 'Prefer using `#{prefer_method}(%<new_arguments>s)` over ' \
+                '`#{target_method}(%<original_arguments>s)`.'
+
+          def on_send(node)
+            return unless node.method?(:#{target_method})
+            return unless (arguments = peel_redundant_parentheses_from(node.arguments))
+            return unless arguments.first.method?(:include?)
+
+            add_offense(node, message: offense_message(arguments))
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.selector, '#{prefer_method}')
+
+              arguments = peel_redundant_parentheses_from(node.arguments)
+
+              new_arguments = [
+                arguments.first.receiver.source,
+                arguments.first.arguments.map(&:source)
+              ].join(', ')
+
+              if enclosed_in_redundant_parentheses?(node)
+                new_arguments = '(' + new_arguments + ')'
+              end
+
+              corrector.replace(first_argument_range(node), new_arguments)
+            end
+          end
+
+          private
+
+          def peel_redundant_parentheses_from(arguments)
+            return arguments unless arguments.first.begin_type?
+
+            peel_redundant_parentheses_from(arguments.first.children)
+          end
+
+          def offense_message(arguments)
+            new_arguments = new_arguments(arguments)
+
+            original_arguments = arguments.map(&:source).join(', ')
+
+            format(
+              MSG,
+              new_arguments: new_arguments,
+              original_arguments: original_arguments
+            )
+          end
+
+          def new_arguments(arguments)
+            message_argument = arguments.last if arguments.first != arguments.last
+
+            [
+              arguments.first.receiver,
+              arguments.first.arguments.first,
+              message_argument
+            ].compact.map(&:source).join(', ')
+          end
+
+          def enclosed_in_redundant_parentheses?(node)
+            node.arguments.first.begin_type?
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -66,11 +66,40 @@ class AssertIncludesTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_include_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert((collection.include?(object)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_includes(collection, object)` over `assert(collection.include?(object))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_includes((collection, object))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_includes_method
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           assert_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_assert_with_non_include_method
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(collection.end_with?(string))
         end
       end
     RUBY

--- a/test/rubocop/cop/minitest/refute_includes_test.rb
+++ b/test/rubocop/cop/minitest/refute_includes_test.rb
@@ -66,11 +66,40 @@ class RefuteIncludesTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_with_include_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute((collection.include?(object)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_includes(collection, object)` over `refute(collection.include?(object))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_includes((collection, object))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_refute_includes_method
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
           refute_includes(collection, object)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_using_refute_with_non_include_method
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute(collection.end_with?(string))
         end
       end
     RUBY


### PR DESCRIPTION
Fixes #52.

This PR fixes a false negative for `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` when an argument is enclosed in redundant parentheses.

Probably will be corrected separately for similar false negatives that other cops will have.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
