### PR TITLE
[Fix #55] Fix an error for `Minitest/AssertIncludes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#55](https://github.com/rubocop-hq/rubocop-minitest/issues/55): Fix an error for `Minitest/AssertIncludes` when using local variable argument. ([@koic][])
+
 ## 0.6.1 (2020-02-18)
 
 ### Bug fixes

--- a/lib/rubocop/cop/mixin/includes_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/includes_cop_rule.rb
@@ -14,7 +14,7 @@ module RuboCop
           def on_send(node)
             return unless node.method?(:#{target_method})
             return unless (arguments = peel_redundant_parentheses_from(node.arguments))
-            return unless arguments.first.method?(:include?)
+            return unless arguments.first.respond_to?(:method?) && arguments.first.method?(:include?)
 
             add_offense(node, message: offense_message(arguments))
           end

--- a/test/rubocop/cop/minitest/assert_includes_test.rb
+++ b/test/rubocop/cop/minitest/assert_includes_test.rb
@@ -104,4 +104,15 @@ class AssertIncludesTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_registers_offense_when_using_assert_with_local_variable
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          collection = []
+          assert(collection)
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #55

This PR fixes an error for `Minitest/AssertIncludes` when using local variable argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
