### PR TITLE
Fix a false negative for `Minitest/AssertMatch` and `Minitest/RefuteMatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#58](https://github.com/rubocop-hq/rubocop-minitest/pull/58): Fix a false negative for `Minitest/AssertMatch` and `Minitest/RefuteMatch` when an argument is enclosed in redundant parentheses. ([@koic][])
+
 ## 0.6.2 (2020-02-19)
 
 ### Bug fixes

--- a/lib/rubocop/cop/minitest/assert_includes.rb
+++ b/lib/rubocop/cop/minitest/assert_includes.rb
@@ -16,9 +16,9 @@ module RuboCop
       #   assert_includes(collection, object, 'the message')
       #
       class AssertIncludes < Cop
-        extend IncludesCopRule
+        extend MinitestCopRule
 
-        rule target_method: :assert, prefer_method: :assert_includes
+        rule :assert, target_method: :include?, prefer_method: :assert_includes
       end
     end
   end

--- a/lib/rubocop/cop/minitest/assert_match.rb
+++ b/lib/rubocop/cop/minitest/assert_match.rb
@@ -16,44 +16,9 @@ module RuboCop
       #   assert_match(matcher, string, 'the message')
       #
       class AssertMatch < Cop
-        include ArgumentRangeHelper
+        extend MinitestCopRule
 
-        MSG = 'Prefer using `assert_match(%<arguments>s)` over ' \
-              '`assert(%<receiver>s)`.'
-
-        def_node_matcher :assert_with_match, <<~PATTERN
-          (send nil? :assert $(send $_ :match $_) $...)
-        PATTERN
-
-        def on_send(node)
-          assert_with_match(node) do
-            |first_receiver_arg, matcher, actual, rest_receiver_arg|
-            message = rest_receiver_arg.first
-            arguments = node_arguments(matcher, actual, message)
-            receiver = [first_receiver_arg.source, message&.source].compact.join(', ')
-
-            offense_message = format(MSG, arguments: arguments, receiver: receiver)
-
-            add_offense(node, message: offense_message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            assert_with_match(node) do |_, matcher, actual|
-              corrector.replace(node.loc.selector, 'assert_match')
-
-              replacement = [matcher, actual].map(&:source).join(', ')
-              corrector.replace(first_argument_range(node), replacement)
-            end
-          end
-        end
-
-        private
-
-        def node_arguments(matcher, actual, message)
-          [matcher.source, actual.source, message&.source].compact.join(', ')
-        end
+        rule :assert, target_method: :match, prefer_method: :assert_match
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_includes.rb
+++ b/lib/rubocop/cop/minitest/refute_includes.rb
@@ -16,9 +16,9 @@ module RuboCop
       #   refute_includes(collection, object, 'the message')
       #
       class RefuteIncludes < Cop
-        extend IncludesCopRule
+        extend MinitestCopRule
 
-        rule target_method: :refute, prefer_method: :refute_includes
+        rule :refute, target_method: :include?, prefer_method: :refute_includes
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_match.rb
+++ b/lib/rubocop/cop/minitest/refute_match.rb
@@ -16,44 +16,9 @@ module RuboCop
       #   refute_match(matcher, string, 'the message')
       #
       class RefuteMatch < Cop
-        include ArgumentRangeHelper
+        extend MinitestCopRule
 
-        MSG = 'Prefer using `refute_match(%<arguments>s)` over ' \
-              '`refute(%<receiver>s)`.'
-
-        def_node_matcher :refute_with_match, <<~PATTERN
-          (send nil? :refute $(send $_ :match $_) $...)
-        PATTERN
-
-        def on_send(node)
-          refute_with_match(node) do
-            |first_receiver_arg, matcher, actual, rest_receiver_arg|
-            message = rest_receiver_arg.first
-            arguments = node_arguments(matcher, actual, message)
-            receiver = [first_receiver_arg.source, message&.source].compact.join(', ')
-
-            offense_message = format(MSG, arguments: arguments, receiver: receiver)
-
-            add_offense(node, message: offense_message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            refute_with_match(node) do |_, matcher, actual|
-              corrector.replace(node.loc.selector, 'refute_match')
-
-              replacement = [matcher, actual].map(&:source).join(', ')
-              corrector.replace(first_argument_range(node), replacement)
-            end
-          end
-        end
-
-        private
-
-        def node_arguments(matcher, actual, message)
-          [matcher.source, actual.source, message&.source].compact.join(', ')
-        end
+        rule :refute, target_method: :match, prefer_method: :refute_match
       end
     end
   end

--- a/lib/rubocop/cop/minitest_cops.rb
+++ b/lib/rubocop/cop/minitest_cops.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'mixin/argument_range_helper'
-require_relative 'mixin/includes_cop_rule'
+require_relative 'mixin/minitest_cop_rule'
 require_relative 'minitest/assert_empty'
 require_relative 'minitest/assert_empty_literal'
 require_relative 'minitest/assert_equal'

--- a/lib/rubocop/cop/mixin/minitest_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/minitest_cop_rule.rb
@@ -3,18 +3,18 @@
 module RuboCop
   module Cop
     # Define the rule for `Minitest/AssertIncludes` and `Minitest/RefuteIncludes` cops.
-    module IncludesCopRule
-      def rule(target_method:, prefer_method:)
+    module MinitestCopRule
+      def rule(assertion_method, target_method:, prefer_method:)
         class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           include ArgumentRangeHelper
 
           MSG = 'Prefer using `#{prefer_method}(%<new_arguments>s)` over ' \
-                '`#{target_method}(%<original_arguments>s)`.'
+                '`#{assertion_method}(%<original_arguments>s)`.'
 
           def on_send(node)
-            return unless node.method?(:#{target_method})
+            return unless node.method?(:#{assertion_method})
             return unless (arguments = peel_redundant_parentheses_from(node.arguments))
-            return unless arguments.first.respond_to?(:method?) && arguments.first.method?(:include?)
+            return unless arguments.first.respond_to?(:method?) && arguments.first.method?(:#{target_method})
 
             add_offense(node, message: offense_message(arguments))
           end

--- a/test/rubocop/cop/minitest/assert_match_test.rb
+++ b/test/rubocop/cop/minitest/assert_match_test.rb
@@ -66,6 +66,25 @@ class AssertMatchTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_match_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert((matcher.match(string)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_match(matcher, string)` over `assert(matcher.match(string))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_match((matcher, string))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_match
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_match_test.rb
+++ b/test/rubocop/cop/minitest/refute_match_test.rb
@@ -66,6 +66,25 @@ class RefuteMatchTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_with_match_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute((matcher.match(string)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_match(matcher, string)` over `refute(matcher.match(string))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_match((matcher, string))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_refute_match
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Follow #54.

This PR fixes a false negative for `Minitest/AssertMatch` and `Minitest/RefuteMatch` when an argument is enclosed in redundant parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
