### PR TITLE
Fix a false negative for `Minitest/AssertRespondTo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#58](https://github.com/rubocop-hq/rubocop-minitest/pull/58): Fix a false negative for `Minitest/AssertMatch` and `Minitest/RefuteMatch` when an argument is enclosed in redundant parentheses. ([@koic][])
+* [#59](https://github.com/rubocop-hq/rubocop-minitest/pull/59): Fix a false negative for `Minitest/AssertRespondTo` and `Minitest/RefuteRespondTo` when an argument is enclosed in redundant parentheses. ([@koic][])
 
 ## 0.6.2 (2020-02-19)
 

--- a/lib/rubocop/cop/minitest/refute_respond_to.rb
+++ b/lib/rubocop/cop/minitest/refute_respond_to.rb
@@ -18,44 +18,9 @@ module RuboCop
       #   refute_respond_to(self, :do_something)
       #
       class RefuteRespondTo < Cop
-        include ArgumentRangeHelper
+        extend MinitestCopRule
 
-        MSG = 'Prefer using `refute_respond_to(%<preferred>s)` over ' \
-              '`refute(%<over>s)`.'
-
-        def_node_matcher :refute_with_respond_to, <<~PATTERN
-          (send nil? :refute $(send $_ :respond_to? $_) $...)
-        PATTERN
-
-        def on_send(node)
-          refute_with_respond_to(node) do |over, object, method, rest_args|
-            custom_message = rest_args.first
-            preferred = build_preferred_arguments(object, method, custom_message)
-            over = [over, custom_message].compact.map(&:source).join(', ')
-            message = format(MSG, preferred: preferred, over: over)
-            add_offense(node, message: message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            refute_with_respond_to(node) do |_, object, method|
-              corrector.replace(node.loc.selector, 'refute_respond_to')
-
-              object = object ? object.source : 'self'
-              replacement = [object, method.source].join(', ')
-              corrector.replace(first_argument_range(node), replacement)
-            end
-          end
-        end
-
-        private
-
-        def build_preferred_arguments(receiver, method, message)
-          receiver = receiver ? receiver.source : 'self'
-
-          [receiver, method.source, message&.source].compact.join(', ')
-        end
+        rule :refute, target_method: :respond_to?, prefer_method: :refute_respond_to
       end
     end
   end

--- a/lib/rubocop/cop/mixin/minitest_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/minitest_cop_rule.rb
@@ -24,9 +24,10 @@ module RuboCop
               corrector.replace(node.loc.selector, '#{prefer_method}')
 
               arguments = peel_redundant_parentheses_from(node.arguments)
+              receiver = correct_receiver(arguments.first.receiver)
 
               new_arguments = [
-                arguments.first.receiver.source,
+                receiver,
                 arguments.first.arguments.map(&:source)
               ].join(', ')
 
@@ -59,17 +60,22 @@ module RuboCop
           end
 
           def new_arguments(arguments)
+            receiver = correct_receiver(arguments.first.receiver)
             message_argument = arguments.last if arguments.first != arguments.last
 
             [
-              arguments.first.receiver,
-              arguments.first.arguments.first,
-              message_argument
-            ].compact.map(&:source).join(', ')
+              receiver,
+              arguments.first.arguments.first.source,
+              message_argument&.source
+            ].compact.join(', ')
           end
 
           def enclosed_in_redundant_parentheses?(node)
             node.arguments.first.begin_type?
+          end
+
+          def correct_receiver(receiver)
+            receiver ? receiver.source : 'self'
           end
         RUBY
       end

--- a/test/rubocop/cop/minitest/assert_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/assert_respond_to_test.rb
@@ -85,6 +85,25 @@ class AssertRespondToTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_respond_to_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert((object.respond_to?(:do_something)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_respond_to(object, :do_something)` over `assert(object.respond_to?(:do_something))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_respond_to((object, :do_something))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_respond_to
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_respond_to_test.rb
+++ b/test/rubocop/cop/minitest/refute_respond_to_test.rb
@@ -85,6 +85,25 @@ class RefuteRespondToTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_with_respond_to_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute((object.respond_to?(:do_something)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_respond_to(object, :do_something)` over `refute(object.respond_to?(:do_something))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_respond_to((object, :do_something))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_respond_to
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Follow #54.

This PR fixes a false negative for `Minitest/AssertRespondTo` and `Minitest/RefuteRespondTo`
when an argument is enclosed in redundant parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
