### PR TITLE
Fix a false negative for `Minitest/AssertInstanceOf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#58](https://github.com/rubocop-hq/rubocop-minitest/pull/58): Fix a false negative for `Minitest/AssertMatch` and `Minitest/RefuteMatch` when an argument is enclosed in redundant parentheses. ([@koic][])
 * [#59](https://github.com/rubocop-hq/rubocop-minitest/pull/59): Fix a false negative for `Minitest/AssertRespondTo` and `Minitest/RefuteRespondTo` when an argument is enclosed in redundant parentheses. ([@koic][])
+* [#61](https://github.com/rubocop-hq/rubocop-minitest/pull/61): Fix a false negative for `Minitest/AssertInstanceOf` and `Minitest/RefuteInstanceOf` when an argument is enclosed in redundant parentheses. ([@koic][])
 
 ## 0.6.2 (2020-02-19)
 

--- a/test/rubocop/cop/minitest/assert_instance_of_test.rb
+++ b/test/rubocop/cop/minitest/assert_instance_of_test.rb
@@ -66,6 +66,25 @@ class AssertInstanceOfTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_instance_of_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert((object.instance_of?(SomeClass)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_instance_of(SomeClass, object)` over `assert(object.instance_of?(SomeClass))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_instance_of((SomeClass, object))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_instance_of_method
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_instance_of_test.rb
+++ b/test/rubocop/cop/minitest/refute_instance_of_test.rb
@@ -66,6 +66,25 @@ class RefuteInstanceOfTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_with_instance_of_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute((object.instance_of?(SomeClass)))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_instance_of(SomeClass, object)` over `refute(object.instance_of?(SomeClass))`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_instance_of((SomeClass, object))
+        end
+      end
+    RUBY
+  end
+
   def refute_instance_of_method
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Follow #54.

Fix a false negative for `Minitest/AssertInstanceOf` and `Minitest/RefuteInstanceOf` when an argument is enclosed in redundant parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
