### PR TITLE
Fix a false negative for `Minitest/AssertEmpty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#58](https://github.com/rubocop-hq/rubocop-minitest/pull/58): Fix a false negative for `Minitest/AssertMatch` and `Minitest/RefuteMatch` when an argument is enclosed in redundant parentheses. ([@koic][])
 * [#59](https://github.com/rubocop-hq/rubocop-minitest/pull/59): Fix a false negative for `Minitest/AssertRespondTo` and `Minitest/RefuteRespondTo` when an argument is enclosed in redundant parentheses. ([@koic][])
 * [#61](https://github.com/rubocop-hq/rubocop-minitest/pull/61): Fix a false negative for `Minitest/AssertInstanceOf` and `Minitest/RefuteInstanceOf` when an argument is enclosed in redundant parentheses. ([@koic][])
+* [#62](https://github.com/rubocop-hq/rubocop-minitest/pull/62): Fix a false negative for `Minitest/AssertEmpty` and `Minitest/RefuteEmpty` when an argument is enclosed in redundant parentheses. ([@koic][])
 
 ## 0.6.2 (2020-02-19)
 

--- a/lib/rubocop/cop/minitest/assert_empty.rb
+++ b/lib/rubocop/cop/minitest/assert_empty.rb
@@ -16,35 +16,9 @@ module RuboCop
       #   assert_empty(object, 'the message')
       #
       class AssertEmpty < Cop
-        include ArgumentRangeHelper
+        extend MinitestCopRule
 
-        MSG = 'Prefer using `assert_empty(%<arguments>s)` over ' \
-              '`assert(%<receiver>s)`.'
-
-        def_node_matcher :assert_with_empty, <<~PATTERN
-          (send nil? :assert $(send $_ :empty?) $...)
-        PATTERN
-
-        def on_send(node)
-          assert_with_empty(node) do |first_receiver_arg, actual, rest_receiver_arg|
-            message = rest_receiver_arg.first
-
-            arguments = [actual.source, message&.source].compact.join(', ')
-            receiver = [first_receiver_arg.source, message&.source].compact.join(', ')
-
-            offense_message = format(MSG, arguments: arguments, receiver: receiver)
-            add_offense(node, message: offense_message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            assert_with_empty(node) do |_, actual_arg|
-              corrector.replace(node.loc.selector, 'assert_empty')
-              corrector.replace(first_argument_range(node), actual_arg.source)
-            end
-          end
-        end
+        rule :assert, target_method: :empty?
       end
     end
   end

--- a/lib/rubocop/cop/minitest/refute_empty.rb
+++ b/lib/rubocop/cop/minitest/refute_empty.rb
@@ -16,35 +16,9 @@ module RuboCop
       #   refute_empty(object, 'the message')
       #
       class RefuteEmpty < Cop
-        include ArgumentRangeHelper
+        extend MinitestCopRule
 
-        MSG = 'Prefer using `refute_empty(%<arguments>s)` over ' \
-              '`refute(%<receiver>s)`.'
-
-        def_node_matcher :refute_with_empty, <<~PATTERN
-          (send nil? :refute $(send $_ :empty?) $...)
-        PATTERN
-
-        def on_send(node)
-          refute_with_empty(node) do |first_receiver_arg, object, rest_receiver_arg|
-            message = rest_receiver_arg.first
-
-            arguments = [object.source, message&.source].compact.join(', ')
-            receiver = [first_receiver_arg.source, message&.source].compact.join(', ')
-
-            offense_message = format(MSG, arguments: arguments, receiver: receiver)
-            add_offense(node, message: offense_message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            refute_with_empty(node) do |_, actual_arg|
-              corrector.replace(node.loc.selector, 'refute_empty')
-              corrector.replace(first_argument_range(node), actual_arg.source)
-            end
-          end
-        end
+        rule :refute, target_method: :empty?
       end
     end
   end

--- a/lib/rubocop/cop/mixin/minitest_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/minitest_cop_rule.rb
@@ -66,13 +66,11 @@ module RuboCop
 
           def new_arguments(arguments)
             receiver = correct_receiver(arguments.first.receiver)
-            method_argument = arguments.first.arguments.first.source
+            method_argument = arguments.first.arguments.first&.source
 
-            if #{inverse}
-              [method_argument, receiver]
-            else
-              [receiver, method_argument]
-            end
+            new_arguments = [receiver, method_argument].compact
+            new_arguments.reverse! if #{inverse}
+            new_arguments
           end
 
           def enclosed_in_redundant_parentheses?(node)

--- a/test/rubocop/cop/minitest/assert_empty_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_test.rb
@@ -66,6 +66,25 @@ class AssertEmptyTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_empty_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert((somestuff.empty?))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)` over `assert(somestuff.empty?)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_empty((somestuff))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_empty_method
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test

--- a/test/rubocop/cop/minitest/refute_empty_test.rb
+++ b/test/rubocop/cop/minitest/refute_empty_test.rb
@@ -66,6 +66,25 @@ class RefuteEmptyTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_refute_with_empty_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute((somestuff.empty?))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `refute_empty(somestuff)` over `refute(somestuff.empty?)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          refute_empty((somestuff))
+        end
+      end
+    RUBY
+  end
+
   def refute_empty_method
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Follow #54.

This PR fixes a false negative for `Minitest/AssertEmpty` and `Minitest/RefuteEmpty` when an argument is enclosed in redundant parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
