### PR TITLE
[Fix #64] Fix `Minitest/GlobalExpectations` autocorrection for chained methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#60](https://github.com/rubocop-hq/rubocop-minitest/issues/60): Fix `Minitest/GlobalExpectations` autocorrection for chained methods. ([@tejasbubane][])
+
 ## 0.7.0 (2020-03-09)
 
 ### New features

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -46,7 +46,7 @@ module RuboCop
           return unless global_expectation?(node)
 
           lambda do |corrector|
-            receiver = node.receiver.loc.selector
+            receiver = node.receiver.source_range
 
             if BLOCK_MATCHERS.include?(node.method_name)
               corrector.insert_before(receiver, '_ { ')

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -35,6 +35,12 @@ class GlobalExpectationsTest < Minitest::Test
         ^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `_(A.foo.bar).must_equal 42`.
       end
     RUBY
+
+    assert_correction(<<~RUBY)
+      it 'does something' do
+        _(A.foo.bar).must_equal 42
+      end
+    RUBY
   end
 
   RuboCop::Cop::Minitest::GlobalExpectations::BLOCK_MATCHERS.each do |matcher|


### PR DESCRIPTION
Closes https://github.com/rubocop-hq/rubocop-minitest/issues/64

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/