### PR TITLE
[Fix #66] Support all expectations of `Minitest::Expectations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#66](https://github.com/rubocop-hq/rubocop-minitest/issues/66): Support all expectations of `Minitest::Expectations` for `Minitest/GlobalExpectations` cop. ([@koic][])
+
 ### Bug fixes
 
 * [#60](https://github.com/rubocop-hq/rubocop-minitest/issues/60): Fix `Minitest/GlobalExpectations` autocorrection for chained methods. ([@tejasbubane][])

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -18,14 +18,15 @@ module RuboCop
         MSG = 'Prefer using `%<corrected>s`.'
 
         VALUE_MATCHERS = %i[
-          be be_close_to be_empty be_instance_of be_kind_of
-          be_nil be_same_as be_silent be_within_epsilon equal
-          include match respond_to must_exist
-        ].map do |matcher|
-          [:"must_#{matcher}", :"wont_#{matcher}"]
-        end.flatten.freeze
+          must_be_empty must_equal must_be_close_to must_be_within_delta
+          must_be_within_epsilon must_include must_be_instance_of must_be_kind_of
+          must_match must_be_nil must_be must_respond_to must_be_same_as
+          path_must_exist path_wont_exist wont_be_empty wont_equal wont_be_close_to
+          wont_be_within_delta wont_be_within_epsilon wont_include wont_be_instance_of
+          wont_be_kind_of wont_match wont_be_nil wont_be wont_respond_to wont_be_same_as
+        ].freeze
 
-        BLOCK_MATCHERS = %i[must_output must_raise must_throw].freeze
+        BLOCK_MATCHERS = %i[must_output must_raise must_be_silent must_throw].freeze
 
         MATCHERS_STR = (VALUE_MATCHERS + BLOCK_MATCHERS).map do |m|
           ":#{m}"


### PR DESCRIPTION
Resolves #66.

This PR supports all expectations of `Minitest::Expectations` for `Minitest/GlobalExpectations` cop.
https://github.com/seattlerb/minitest/blob/v5.14.0/lib/minitest/expectations.rb

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
