### PR TITLE
Fix a false negative for `Minitest/GlobalExpectations` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#60](https://github.com/rubocop-hq/rubocop-minitest/issues/60): Fix `Minitest/GlobalExpectations` autocorrection for chained methods. ([@tejasbubane][])
+* [#69](https://github.com/rubocop-hq/rubocop-minitest/pull/69): Fix a false negative for `Minitest/GlobalExpectations` cop when using a variable or a hash index for receiver. ([@koic][])
 
 ## 0.7.0 (2020-03-09)
 

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -33,7 +33,11 @@ module RuboCop
         end.join(' ').freeze
 
         def_node_matcher :global_expectation?, <<~PATTERN
-          (send (send _ _) {#{MATCHERS_STR}} ...)
+          (send {
+            (send _ _)
+            ({lvar ivar cvar gvar} _)
+            (send {(send _ _) ({lvar ivar cvar gvar} _)} _ _)
+          } {#{MATCHERS_STR}} ...)
         PATTERN
 
         def on_send(node)

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -19,6 +19,142 @@ class GlobalExpectationsTest < Minitest::Test
       RUBY
     end
 
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_lvar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          n = do_something
+          n.#{matcher} 42
+          #{'^' * (matcher.length + 5)} Prefer using `_(n).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          n = do_something
+          _(n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_ivar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          @n = do_something
+          @n.#{matcher} 42
+          #{'^' * (matcher.length + 6)} Prefer using `_(@n).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          @n = do_something
+          _(@n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_cvar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          @@n = do_something
+          @@n.#{matcher} 42
+          #{'^' * (matcher.length + 7)} Prefer using `_(@@n).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          @@n = do_something
+          _(@@n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_gvar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          $n = do_something
+          $n.#{matcher} 42
+          #{'^' * (matcher.length + 6)} Prefer using `_($n).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          $n = do_something
+          _($n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_hash_as_lvar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          n = do_something
+          n[:foo].#{matcher} 42
+          #{'^' * (matcher.length + 11)} Prefer using `_(n[:foo]).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          n = do_something
+          _(n[:foo]).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_hash_as_ivar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          @n = do_something
+          @n[:foo].#{matcher} 42
+          #{'^' * (matcher.length + 12)} Prefer using `_(@n[:foo]).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          @n = do_something
+          _(@n[:foo]).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_hash_as_cvar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          @@n = do_something
+          @@n[:foo].#{matcher} 42
+          #{'^' * (matcher.length + 13)} Prefer using `_(@@n[:foo]).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          @@n = do_something
+          _(@@n[:foo]).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_hash_as_gvar") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          $n = do_something
+          $n[:foo].#{matcher} 42
+          #{'^' * (matcher.length + 12)} Prefer using `_($n[:foo]).#{matcher} 42`.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          $n = do_something
+          _($n[:foo]).#{matcher} 42
+        end
+      RUBY
+    end
+
     define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}") do
       assert_no_offenses(<<~RUBY)
         it 'does something' do


### PR DESCRIPTION
Fix a false negative for `Minitest/GlobalExpectations` cop when using a variable or a hash index for receiver.

The following is a false nagative example.

```ruby
signed_url_params["Signature"].must_equal [Base64.strict_encode64("native-signature").delete("\n")]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
