### PR TITLE
Change highlight area for `Minitest/GlobalExpectations`

### DIFF
--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   _(wonts).wont_match expected_wonts
       #   _ { musts }.must_raise TypeError
       class GlobalExpectations < Cop
-        MSG = 'Prefer using `%<corrected>s`.'
+        MSG = 'Use `%<preferred>s` instead.'
 
         VALUE_MATCHERS = %i[
           must_be_empty must_equal must_be_close_to must_be_within_delta
@@ -45,8 +45,8 @@ module RuboCop
         def on_send(node)
           return unless global_expectation?(node)
 
-          message = format(MSG, corrected: correct_suggestion(node))
-          add_offense(node, message: message)
+          message = format(MSG, preferred: preferred_receiver(node))
+          add_offense(node, location: node.receiver.source_range, message: message)
         end
 
         def autocorrect(node)
@@ -67,12 +67,12 @@ module RuboCop
 
         private
 
-        def correct_suggestion(node)
+        def preferred_receiver(node)
           source = node.receiver.source
           if BLOCK_MATCHERS.include?(node.method_name)
-            node.source.sub(source, "_ { #{source} }")
+            "_ { #{source} }"
           else
-            node.source.sub(source, "_(#{source})")
+            "_(#{source})"
           end
         end
       end

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -8,7 +8,7 @@ class GlobalExpectationsTest < Minitest::Test
       assert_offense(<<~RUBY)
         it 'does something' do
           n.#{matcher} 42
-          #{'^' * (matcher.length + 5)} Prefer using `_(n).#{matcher} 42`.
+          ^ Use `_(n)` instead.
         end
       RUBY
 
@@ -24,7 +24,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           n = do_something
           n.#{matcher} 42
-          #{'^' * (matcher.length + 5)} Prefer using `_(n).#{matcher} 42`.
+          ^ Use `_(n)` instead.
         end
       RUBY
 
@@ -41,7 +41,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           @n = do_something
           @n.#{matcher} 42
-          #{'^' * (matcher.length + 6)} Prefer using `_(@n).#{matcher} 42`.
+          ^^ Use `_(@n)` instead.
         end
       RUBY
 
@@ -58,7 +58,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           @@n = do_something
           @@n.#{matcher} 42
-          #{'^' * (matcher.length + 7)} Prefer using `_(@@n).#{matcher} 42`.
+          ^^^ Use `_(@@n)` instead.
         end
       RUBY
 
@@ -75,7 +75,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           $n = do_something
           $n.#{matcher} 42
-          #{'^' * (matcher.length + 6)} Prefer using `_($n).#{matcher} 42`.
+          ^^ Use `_($n)` instead.
         end
       RUBY
 
@@ -92,7 +92,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           n = do_something
           n[:foo].#{matcher} 42
-          #{'^' * (matcher.length + 11)} Prefer using `_(n[:foo]).#{matcher} 42`.
+          ^^^^^^^ Use `_(n[:foo])` instead.
         end
       RUBY
 
@@ -109,7 +109,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           @n = do_something
           @n[:foo].#{matcher} 42
-          #{'^' * (matcher.length + 12)} Prefer using `_(@n[:foo]).#{matcher} 42`.
+          ^^^^^^^^ Use `_(@n[:foo])` instead.
         end
       RUBY
 
@@ -126,7 +126,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           @@n = do_something
           @@n[:foo].#{matcher} 42
-          #{'^' * (matcher.length + 13)} Prefer using `_(@@n[:foo]).#{matcher} 42`.
+          ^^^^^^^^^ Use `_(@@n[:foo])` instead.
         end
       RUBY
 
@@ -143,7 +143,7 @@ class GlobalExpectationsTest < Minitest::Test
         it 'does something' do
           $n = do_something
           $n[:foo].#{matcher} 42
-          #{'^' * (matcher.length + 12)} Prefer using `_($n[:foo]).#{matcher} 42`.
+          ^^^^^^^^ Use `_($n[:foo])` instead.
         end
       RUBY
 
@@ -168,7 +168,7 @@ class GlobalExpectationsTest < Minitest::Test
     assert_offense(<<~RUBY)
       it 'does something' do
         A.foo.bar.must_equal 42
-        ^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `_(A.foo.bar).must_equal 42`.
+        ^^^^^^^^^ Use `_(A.foo.bar)` instead.
       end
     RUBY
 
@@ -184,7 +184,7 @@ class GlobalExpectationsTest < Minitest::Test
       assert_offense(<<~RUBY)
         it 'does something' do
           n.#{matcher} 42
-          #{'^' * (matcher.length + 5)} Prefer using `_ { n }.#{matcher} 42`.
+          ^ Use `_ { n }` instead.
         end
       RUBY
 


### PR DESCRIPTION
This PR changes highlight area and offense message for `Minitest/GlobalExpectations` cop.

## Before

```console
% bundle exec rubocop --only Minitest/GlobalExpectations -a
(snip)

test/google/cloud/storage/bucket_compose_test.rb:59:5: C: [Corrected]
Minitest/GlobalExpectations: Prefer using _(new_file.name).must_equal
file_3_name.
    new_file.name.must_equal file_3_name
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## After

```console
% bundle exec rubocop --only Minitest/GlobalExpectations -a
(snip)

test/google/cloud/storage/bucket_compose_test.rb:59:5: C: [Corrected]
Minitest/GlobalExpectations: Use _(new_file.name) instead.
    new_file.name.must_equal file_3_name
    ^^^^^^^^^^^^^
```

This change will clarify an offense area.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
