### PR TITLE
Fix a false negative for `Minitest/AssertEqual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#60](https://github.com/rubocop-hq/rubocop-minitest/issues/60): Fix `Minitest/GlobalExpectations` autocorrection for chained methods. ([@tejasbubane][])
 * [#69](https://github.com/rubocop-hq/rubocop-minitest/pull/69): Fix a false negative for `Minitest/GlobalExpectations` cop when using a variable or a hash index for receiver. ([@koic][])
+* [#71](https://github.com/rubocop-hq/rubocop-minitest/pull/71): Fix a false negative for `Minitest/AssertEqual` when an argument is enclosed in redundant parentheses. ([@koic][])
 
 ## 0.7.0 (2020-03-09)
 

--- a/lib/rubocop/cop/minitest/assert_equal.rb
+++ b/lib/rubocop/cop/minitest/assert_equal.rb
@@ -14,38 +14,9 @@ module RuboCop
       #   assert_equal("rubocop-minitest", actual)
       #
       class AssertEqual < Cop
-        include ArgumentRangeHelper
+        extend MinitestCopRule
 
-        MSG = 'Prefer using `assert_equal(%<preferred>s)` over ' \
-              '`assert(%<over>s)`.'
-
-        def_node_matcher :assert_equal, <<~PATTERN
-          (send nil? :assert $(send $_ :== $_) $...)
-        PATTERN
-
-        def on_send(node)
-          assert_equal(node) do |first_receiver_arg, expected, actual, rest_receiver_arg|
-            message = rest_receiver_arg.first
-            preferred = [expected.source, actual.source, message&.source]
-                        .compact.join(', ')
-            over = [first_receiver_arg.source, message&.source].compact.join(', ')
-
-            offense_message = format(MSG, preferred: preferred, over: over)
-
-            add_offense(node, message: offense_message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            assert_equal(node) do |_, expected, actual|
-              corrector.replace(node.loc.selector, 'assert_equal')
-
-              replacement = [expected, actual].map(&:source).join(', ')
-              corrector.replace(first_argument_range(node), replacement)
-            end
-          end
-        end
+        define_rule :assert, target_method: :==, preferred_method: :assert_equal
       end
     end
   end

--- a/test/rubocop/cop/minitest/assert_equal_test.rb
+++ b/test/rubocop/cop/minitest/assert_equal_test.rb
@@ -104,6 +104,25 @@ class AssertEqualTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_using_assert_with_equal_in_redundant_parentheses
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert(('rubocop-minitest' == actual))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_equal('rubocop-minitest', actual)` over `assert('rubocop-minitest' == actual)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(('rubocop-minitest', actual))
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_using_assert_equal
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Follow #54.

This PR fixes a false negative for `Minitest/AssertEqual` when an argument is enclosed in redundant parentheses.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
