### PR TITLE
Fix some false negatives for `Minitest/GlobalExpectations`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,4 +20,4 @@ Metrics/MethodLength:
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Layout/LineLength:
-  Max: 100
+  Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#72](https://github.com/rubocop-hq/rubocop-minitest/pull/72): Fix some false negatives for `Minitest/GlobalExpectations`. ([@andrykonchin][])
+
 ## 0.8.0 (2020-03-24)
 
 ### New features
@@ -119,3 +123,4 @@
 [@abhaynikam]: https://github.com/abhaynikam
 [@herwinw]: https://github.com/herwinw
 [@fsateler]: https://github.com/fsateler
+[@andrykonchin]: https://github.com/andrykonchin

--- a/lib/rubocop/cop/mixin/minitest_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/minitest_cop_rule.rb
@@ -22,9 +22,7 @@ module RuboCop
       # @param inverse [Boolean] An optional param. Order of arguments replaced by auto-correction.
       #
       def define_rule(assertion_method, target_method:, preferred_method: nil, inverse: false)
-        if preferred_method.nil?
-          preferred_method = "#{assertion_method}_#{target_method.to_s.delete('?')}"
-        end
+        preferred_method = "#{assertion_method}_#{target_method.to_s.delete('?')}" if preferred_method.nil?
 
         class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           include ArgumentRangeHelper

--- a/test/assertion_helper.rb
+++ b/test/assertion_helper.rb
@@ -29,9 +29,7 @@ module AssertionHelper
     @cop.instance_variable_get(:@options)[:auto_correct] = true
 
     expected_annotations = RuboCop::RSpec::ExpectOffense::AnnotatedSource.parse(source)
-    if expected_annotations.plain_source == source
-      raise 'Use `assert_no_offenses` to assert that no offenses are found'
-    end
+    raise 'Use `assert_no_offenses` to assert that no offenses are found' if expected_annotations.plain_source == source
 
     @processed_source = inspect_source(expected_annotations.plain_source, @cop, file)
 

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -162,6 +162,67 @@ class GlobalExpectationsTest < Minitest::Test
         end
       RUBY
     end
+
+    define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}_with_value_method") do
+      assert_no_offenses(<<~RUBY)
+        it 'does something' do
+          value(n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}_with_expect_method") do
+      assert_no_offenses(<<~RUBY)
+        it 'does something' do
+          expect(n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_chained_hash_reference") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          options[:a][:b].#{matcher} 0
+          ^^^^^^^^^^^^^^^ Use `_(options[:a][:b])` instead.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          _(options[:a][:b]).#{matcher} 0
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_method_call_with_params") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          foo(a).#{matcher} 0
+          ^^^^^^ Use `_(foo(a))` instead.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          _(foo(a)).#{matcher} 0
+        end
+      RUBY
+    end
+
+    define_method(:"test_registers_offense_when_using_global_#{matcher}_for_constant") do
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          C.#{matcher}(:a)
+          ^ Use `_(C)` instead.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          _(C).#{matcher}(:a)
+        end
+      RUBY
+    end
   end
 
   def test_works_with_chained_method_calls
@@ -199,6 +260,38 @@ class GlobalExpectationsTest < Minitest::Test
       assert_no_offenses(<<~RUBY)
         it 'does something' do
           _ { n }.#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}_with_value_method") do
+      assert_no_offenses(<<~RUBY)
+        it 'does something' do
+          value(n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}_with_expect_method") do
+      assert_no_offenses(<<~RUBY)
+        it 'does something' do
+          expect(n).#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}_with_value_method_and_block") do
+      assert_no_offenses(<<~RUBY)
+        it 'does something' do
+          value { n }.#{matcher} 42
+        end
+      RUBY
+    end
+
+    define_method(:"test_no_offense_when_using_expect_form_of_#{matcher}_with_expect_method_and_block") do
+      assert_no_offenses(<<~RUBY)
+        it 'does something' do
+          expect { n }.#{matcher} 42
         end
       RUBY
     end


### PR DESCRIPTION
Fixed some use cases for the `Minitest/GlobalExpectations` cop.

I have noticed there are cases when the cop doesn't produce offenses:
- expectation for constant e.g. class/module
- method call with arguments
- expectation for chained hash references

Let's look at some examples which the cope ignores:

```ruby
response[1]['X-Runtime'].must_match /[\d\.]+/

::File.read(::File.join(@def_disk_cache, 'path', 'to', 'blah.html')).must_equal @def_value.first

Rack::Contrib.must_respond_to(:release)
```

## Related links

- https://github.com/rubocop-hq/rubocop-minitest/issues/60
- https://github.com/rubocop-hq/rubocop-minitest/pull/63
- https://github.com/rubocop-hq/rubocop-minitest/pull/69

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
