### PR TITLE
[Fix #73] The Minitest department works on `_test.rb` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#73](https://github.com/rubocop-hq/rubocop-minitest/issues/73): The Minitest department works on file names end with `_test.rb` by default. ([@koic][])
+
 ## 0.8.1 (2020-04-06)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,7 @@ Minitest:
   Enabled: true
   Include:
     - '**/test/**/*'
+    - '**/*_test.rb'
 
 Minitest/AssertEmpty:
   Description: 'This cop enforces the test to use `assert_empty` instead of using `assert(object.empty?)`.'


### PR DESCRIPTION
Fixes #73.

This PR changes the Minitest department works on file names end with `_test.rb` by default.

RuboCop Minitest only targets files in `test` directory by default until v0.8.1.

```yaml
Minitest:
  Enabled: true
  Include:
    - '**/test/**/*'
```

https://github.com/rubocop-hq/rubocop-minitest/blob/v0.8.1/config/default.yml

But test files may be located in a directory other than `test` directory.
This PR adds files that end of filename is `_test.rb` to be considered test files.

This behavior is similar to how RuboCop RSpec works on `_spec.rb`.
https://github.com/rubocop-hq/rubocop-rspec/blob/v1.38.1/config/default.yml#L5

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
