### PR TITLE
[Fix #75] Fix a false negative for `Minitest/GlobalExpectations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#75](https://github.com/rubocop-hq/rubocop-minitest/issues/75): Fix a false negative for `Minitest/GlobalExpectations` when using global expectation methods with no arguments. ([@koic][])
+
 ### Changes
 
 * [#73](https://github.com/rubocop-hq/rubocop-minitest/issues/73): The Minitest department works on file names end with `_test.rb` by default. ([@koic][])

--- a/lib/rubocop/cop/minitest/global_expectations.rb
+++ b/lib/rubocop/cop/minitest/global_expectations.rb
@@ -44,7 +44,7 @@ module RuboCop
         end.join(' ').freeze
 
         def_node_matcher :value_global_expectation?, <<~PATTERN
-          (send !(send nil? {#{DSL_METHODS_LIST}} _) {#{VALUE_MATCHERS_STR}} _)
+          (send !(send nil? {#{DSL_METHODS_LIST}} _) {#{VALUE_MATCHERS_STR}} ...)
         PATTERN
 
         def_node_matcher :block_global_expectation?, <<~PATTERN

--- a/test/rubocop/cop/minitest/global_expectations_test.rb
+++ b/test/rubocop/cop/minitest/global_expectations_test.rb
@@ -295,5 +295,20 @@ class GlobalExpectationsTest < Minitest::Test
         end
       RUBY
     end
+
+    def test_registers_offense_when_using_global_expectations_without_arguments
+      assert_offense(<<~RUBY)
+        it 'does something' do
+          n.must_be_nil
+          ^ Use `_(n)` instead.
+        end
+      RUBY
+
+      assert_correction(<<~RUBY)
+        it 'does something' do
+          _(n).must_be_nil
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #75

This PR fixes a false negative for `Minitest/GlobalExpectations` when using global expectation methods with no arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
