### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ workflows:
   build:
     jobs:
       - rake_default:
-          name: Ruby 2.3
-          image: circleci/ruby:2.3
-      - rake_default:
           name: Ruby 2.4
           image: circleci/ruby:2.4
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
   - rubocop-minitest
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Naming/PredicateName:
   # Method define macros for dynamically generated method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#73](https://github.com/rubocop-hq/rubocop-minitest/issues/73): The Minitest department works on file names end with `_test.rb` by default. ([@koic][])
+* [#77](https://github.com/rubocop-hq/rubocop-minitest/pull/77): **(BREAKING)** Drop support for Ruby 2.3. ([@koic][])
 
 ## 0.8.1 (2020-04-06)
 

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.license = 'MIT'
 
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
   spec.metadata = {
     'homepage_uri' => 'https://docs.rubocop.org/projects/minitest/',
     'changelog_uri' => 'https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md',

--- a/test/assertion_helper.rb
+++ b/test/assertion_helper.rb
@@ -87,6 +87,6 @@ module AssertionHelper
   end
 
   def ruby_version
-    2.3
+    2.4
   end
 end


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/7869.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
