### PR TITLE
Add new_cops rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ end
 
 require 'rubocop/rake_task'
 require 'rake/testtask'
+require_relative 'lib/rubocop/cop/generator'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
@@ -36,3 +37,31 @@ task default: %i[
   test
   internal_investigation
 ]
+
+desc 'Generate a new cop template'
+task :new_cop, [:cop] do |_task, args|
+  require 'rubocop'
+
+  cop_name = args.fetch(:cop) do
+    warn 'usage: bundle exec rake new_cop[Department/Name]'
+    exit!
+  end
+
+  github_user = `git config github.user`.chop
+  github_user = 'your_id' if github_user.empty?
+
+  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+
+  generator.write_source
+  generator.write_test
+  generator.inject_require(root_file_path: 'lib/rubocop/cop/minitest_cops.rb')
+  generator.inject_config(config_file_path: 'config/default.yml', version_added: bump_minor_version)
+
+  puts generator.todo
+end
+
+def bump_minor_version
+  major, minor, _patch = RuboCop::Minitest::VERSION.split('.')
+
+  "#{major}.#{minor.succ}"
+end

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Source and test generator for new cops
+    #
+    # This generator will take a cop name and generate a source file
+    # and test file when given a valid qualified cop name.
+    class Generator
+      TEST_TEMPLATE = <<~TEST
+        # frozen_string_literal: true
+
+        require 'test_helper'
+
+        class %<cop_name>sTest < Minitest::Test
+          def test_registers_offense_when_using_bad_method
+            assert_offense(<<~RUBY)
+              bad_method
+              ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
+            RUBY
+
+            assert_correction(<<~RUBY)
+              good_method
+            RUBY
+          end
+
+          def test_does_not_register_offense_when_using_good_method
+            assert_no_offenses(<<~RUBY)
+              good_method
+            RUBY
+          end
+        end
+      TEST
+
+      def write_test
+        write_unless_file_exists(test_path, generated_test)
+      end
+
+      private
+
+      def test_path
+        File.join(
+          'test',
+          'rubocop',
+          'cop',
+          'minitest',
+          "#{snake_case(badge.cop_name.to_s)}_test.rb"
+        )
+      end
+
+      def generated_test
+        generate(TEST_TEMPLATE)
+      end
+    end
+  end
+end


### PR DESCRIPTION
To generate new cop

Like https://github.com/rubocop-hq/rubocop-rspec/blob/master/lib/rubocop/cop/rspec_cops.rb

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/