### PR TITLE
Drop support for RuboCop 0.81 or lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#82](https://github.com/rubocop-hq/rubocop-minitest/pull/82): Drop support for RuboCop 0.81 or lower. ([@koic][])
+
 ## 0.9.0 (2020-04-13)
 
 ### Bug fixes

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.74'
+  spec.add_runtime_dependency 'rubocop', '>= 0.82'
   spec.add_development_dependency 'minitest', '~> 5.11'
 end


### PR DESCRIPTION
Follow up to https://github.com/rubocop-hq/rubocop-performance/issues/111.

This PR prepares to use RuboCop's new development API.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
