### PR TITLE
Add autocorrect to `Rails/AssertEmptyLiteral` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#84](https://github.com/rubocop-hq/rubocop-minitest/pull/84): New cops `AssertKindOf` and `RefuteKindOf` check for use of `assert_kind_of`/`refute_kind_of` instead of `assert(foo.kind_of?(Class))`/`refute(foo.kind_of?(Class))`. ([@fatkodima][])
+* [#85](https://github.com/rubocop-hq/rubocop-minitest/pull/85): Add autocorrect to `Rails/AssertEmptyLiteral` cop. ([@fatkodima][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -13,7 +13,9 @@ Minitest/AssertEmpty:
 Minitest/AssertEmptyLiteral:
   Description: 'This cop enforces the test to use `assert_empty` instead of using `assert([], object)` or `assert({}, object)`.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.5'
+  VersionChanged: '0.10'
 
 Minitest/AssertEqual:
   Description: 'This cop enforces the test to use `assert_equal` instead of using `assert(expected == actual)`.'

--- a/docs/modules/ROOT/pages/cops_minitest.adoc
+++ b/docs/modules/ROOT/pages/cops_minitest.adoc
@@ -39,9 +39,9 @@ assert_empty(object, 'message')
 
 | Enabled
 | Yes
-| No
+| Yes (Unsafe)
 | 0.5
-| -
+| 0.10
 |===
 
 This cop enforces the test to use `assert_empty`

--- a/test/rubocop/cop/minitest/assert_empty_literal_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_literal_test.rb
@@ -12,6 +12,14 @@ class AssertEmptyLiteralTest < Minitest::Test
         end
       end
     RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_empty(somestuff)
+        end
+      end
+    RUBY
   end
 
   def test_registers_offense_when_asserting_empty_hash
@@ -20,6 +28,14 @@ class AssertEmptyLiteralTest < Minitest::Test
         def test_do_something
           assert({}, somestuff)
           ^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)` over `assert({}, somestuff)`.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_empty(somestuff)
         end
       end
     RUBY


### PR DESCRIPTION
1. Added autocorrection
2. Also this cop was not implemented correctly as it should check against `assert_equal([], something)`, not `assert([], something)` - changed that

For reference: http://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert