### PR TITLE
Update `Minitest::Test` child check

### DIFF
--- a/lib/rubocop/cop/minitest/multiple_assertions.rb
+++ b/lib/rubocop/cop/minitest/multiple_assertions.rb
@@ -33,7 +33,7 @@ module RuboCop
         MSG = 'Test case has too many assertions [%<total>d/%<max>d].'
 
         def on_class(class_node)
-          return unless minitest_test_subclass?(class_node)
+          return unless test_class?(class_node)
 
           test_cases(class_node).each do |node|
             assertions_count = assertions_count(node)

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -49,13 +49,9 @@ module RuboCop
 
       private
 
-      def minitest_test_subclass?(class_node)
-        minitest_test?(class_node.parent_class)
+      def test_class?(class_node)
+        class_node.parent_class && class_node.identifier.source.end_with?('Test')
       end
-
-      def_node_matcher :minitest_test?, <<~PATTERN
-        (const (const nil? :Minitest) :Test)
-      PATTERN
 
       def test_cases(class_node)
         class_def = class_node.body

--- a/test/rubocop/cop/minitest/multiple_assertions_test.rb
+++ b/test/rubocop/cop/minitest/multiple_assertions_test.rb
@@ -19,7 +19,30 @@ class MultipleAssertionsTest < Minitest::Test
     RUBY
   end
 
-  def test_checks_only_minitest_test_children
+  def test_checks_when_inheriting_some_class_and_class_name_ending_with_test
+    assert_offense(<<~RUBY)
+      class FooTest < ActiveSupport::TestCase
+        def test_asserts_twice
+            ^^^^^^^^^^^^^^^^^^ Test case has too many assertions [2/1].
+          assert_equal(foo, bar)
+          assert_empty(array)
+        end
+      end
+    RUBY
+  end
+
+  def test_checks_when_inheriting_some_class_and_class_name_does_end_with_test
+    assert_no_offenses(<<~RUBY)
+      class Foo < Base
+        def test_asserts_twice
+          assert_equal(foo, bar)
+          assert_empty(array)
+        end
+      end
+    RUBY
+  end
+
+  def test_checks_when_not_inheriting_some_class_and_class_name_ending_with_test
     assert_no_offenses(<<~RUBY)
       class FooTest
         def test_asserts_twice


### PR DESCRIPTION
This PR removes `MinitestExplorationHelpers#minitest_test_subclass` because For example, Rails testing does not inherit `Minitest::Test` directly but inherits `ActiveSupport::TestCase`.

A class that inherits some superclass and whose class name ends with `Test` is identified as a test class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
