### PR TITLE
[Fix #101, #103] LiteralAsActualArgument parsing and autocorrect errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* [#92](https://github.com/rubocop-hq/rubocop-minitest/pull/92): Add new `Minitest/LiteralAsActualArgument` cop. ([@fatkodima][])
+* [#92](https://github.com/rubocop-hq/rubocop-minitest/pull/92): Add new `Minitest/LiteralAsActualArgument` cop. ([@fatkodima][], [@tsmmark][])
 * [#95](https://github.com/rubocop-hq/rubocop-minitest/pull/95): Add new `Minitest/AssertionInLifecycleHook` cop. ([@fatkodima][])
 * [#91](https://github.com/rubocop-hq/rubocop-minitest/pull/91): Add new `Minitest/AssertInDelta` and `Minitest/RefuteInDelta` cops. ([@fatkodima][])
 * [#89](https://github.com/rubocop-hq/rubocop-minitest/pull/89): Add new `Minitest/TestMethodName` cop. ([@fatkodima][])
@@ -155,3 +155,4 @@
 [@fsateler]: https://github.com/fsateler
 [@andrykonchin]: https://github.com/andrykonchin
 [@fatkodima]: https://github.com/fatkodima
+[@tsmmark]: https://github.com/tsmmark

--- a/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
+++ b/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
@@ -33,9 +33,16 @@ module RuboCop
 
         def autocorrect(node)
           expected, actual, message = *node.arguments
-          arguments = [actual.source, expected.source, message&.source].compact.join(', ')
 
           lambda do |corrector|
+            new_actual_source =
+              if actual.hash_type? && !actual.braces?
+                "{#{actual.source}}"
+              else
+                actual.source
+              end
+            arguments = [new_actual_source, expected.source, message&.source].compact.join(', ')
+
             corrector.replace(node, "assert_equal(#{arguments})")
           end
         end

--- a/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
+++ b/lib/rubocop/cop/minitest/literal_as_actual_argument.rb
@@ -18,14 +18,17 @@ module RuboCop
       #   assert_equal [1, 2], foo, 'message'
       #
       class LiteralAsActualArgument < Cop
+        include ArgumentRangeHelper
+
         MSG = 'Replace the literal with the first argument.'
 
         def on_send(node)
           return unless node.method?(:assert_equal)
 
           actual = node.arguments[1]
-          range = arguments_range(node)
-          add_offense(node, location: range) if actual.recursive_basic_literal?
+          return unless actual
+
+          add_offense(node, location: all_arguments_range(node)) if actual.recursive_basic_literal?
         end
 
         def autocorrect(node)
@@ -35,12 +38,6 @@ module RuboCop
           lambda do |corrector|
             corrector.replace(node, "assert_equal(#{arguments})")
           end
-        end
-
-        private
-
-        def arguments_range(node)
-          node.loc.begin.end.join(node.loc.end.begin)
         end
       end
     end

--- a/lib/rubocop/cop/mixin/argument_range_helper.rb
+++ b/lib/rubocop/cop/mixin/argument_range_helper.rb
@@ -26,6 +26,16 @@ module RuboCop
           second_argument.source_range.end_pos
         )
       end
+
+      def all_arguments_range(node)
+        first_argument = node.first_argument
+        last_argument = node.arguments.last
+
+        range_between(
+          first_argument.source_range.begin_pos,
+          last_argument.source_range.end_pos
+        )
+      end
     end
   end
 end

--- a/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
+++ b/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
@@ -60,4 +60,24 @@ class LiteralAsActualArgumentTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_parens_omitted
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal 2, foo
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_given_splat
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(*foo)
+        end
+      end
+    RUBY
+  end
 end

--- a/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
+++ b/test/rubocop/cop/minitest/literal_as_actual_argument_test.rb
@@ -41,6 +41,25 @@ class LiteralAsActualArgumentTest < Minitest::Test
     RUBY
   end
 
+  def test_registers_offense_when_actual_is_hash_without_curly_braces
+    assert_offense(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal(foo, key: :value)
+                       ^^^^^^^^^^^^^^^^ Replace the literal with the first argument.
+        end
+      end
+    RUBY
+
+    assert_correction(<<~RUBY)
+      class FooTest < Minitest::Test
+        def test_do_something
+          assert_equal({key: :value}, foo)
+        end
+      end
+    RUBY
+  end
+
   def test_does_not_register_offense_when_actual_is_not_literal
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test


### PR DESCRIPTION
Fixes #101 and fixes #103. More info in those issues

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
