### PR TITLE
Require RuboCop 0.87 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Changes
 
-* [#82](https://github.com/rubocop-hq/rubocop-minitest/pull/82): Drop support for RuboCop 0.81 or lower. ([@koic][])
+* [#104](https://github.com/rubocop-hq/rubocop-minitest/pull/104): Require RuboCop 0.87 or higher. ([@koic][])
 
 ## 0.9.0 (2020-04-13)
 

--- a/rubocop-minitest.gemspec
+++ b/rubocop-minitest.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.82'
+  spec.add_runtime_dependency 'rubocop', '>= 0.87'
   spec.add_development_dependency 'minitest', '~> 5.11'
 end


### PR DESCRIPTION
RuboCop Minitest requires RuboCop 0.87 or higher due to use the new Autocorrection API.
https://github.com/rubocop-hq/rubocop/pull/7868

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
