### PR TITLE
[Fix #106] Fix an errof for `Minitest/AssertOutput` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#106](https://github.com/rubocop-hq/rubocop-minitest/issues/106): Fix an error for `Minitest/AssertOutput` when using gvar at top level. ([@koic][])
+
 ## 0.10.0 (2020-07-12)
 
 ### New features

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -26,7 +26,7 @@ module RuboCop
       end
 
       def test_case?(node)
-        return false unless node.def_type? && test_case_name?(node.method_name)
+        return false unless node&.def_type? && test_case_name?(node.method_name)
 
         class_ancestor = node.each_ancestor(:class).first
         test_class?(class_ancestor)

--- a/test/rubocop/cop/minitest/assert_output_test.rb
+++ b/test/rubocop/cop/minitest/assert_output_test.rb
@@ -47,4 +47,10 @@ class AssertOutputTest < Minitest::Test
       end
     RUBY
   end
+
+  def test_does_not_register_offense_when_using_gvar_at_top_level
+    assert_no_offenses(<<~RUBY)
+      $foo = false
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #106.

This PR fixes an error for `Minitest/AssertOutput` when using gvar at top level.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
