### PR TITLE
Fix assert typo in Minitest/RefuteEqual

### DIFF
--- a/docs/modules/ROOT/pages/cops_minitest.adoc
+++ b/docs/modules/ROOT/pages/cops_minitest.adoc
@@ -638,7 +638,7 @@ refute_empty(object, 'message')
 |===
 
 This cop enforces the use of `refute_equal(expected, object)`
-over `assert_equal(expected != actual)` or `assert(! expected == actual)`.
+over `assert(expected != actual)` or `assert(! expected == actual)`.
 
 === Examples
 

--- a/lib/rubocop/cop/minitest/refute_equal.rb
+++ b/lib/rubocop/cop/minitest/refute_equal.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the use of `refute_equal(expected, object)`
-      # over `assert_equal(expected != actual)` or `assert(! expected == actual)`.
+      # over `assert(expected != actual)` or `assert(! expected == actual)`.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Use assert with a comparison instead of assert_equal. assert_equal takes 2
arguments, not 1 and both the next example and the bad examples below use
assert with a comparison.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
