### PR TITLE
Add documentation checks on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,24 @@ jobs:
       - run: bundle install
       - run: bundle exec rake
 
+  # Miscellaneous tasks
+  documentation-checks:
+    docker:
+      - image: circleci/ruby
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: Check documentation syntax
+          command: bundle exec rake documentation_syntax_check
+      - run:
+          name: Build documentation and verify that doc files are in sync
+          command: bundle exec rake verify_cops_documentation
+
 workflows:
   build:
     jobs:
+      - documentation-checks
       - rake_default:
           name: Ruby 2.4
           image: circleci/ruby:2.4


### PR DESCRIPTION
This PR adds documentation checks on CI.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
