### PR TITLE
[Fix #113] Fix an error for `Minitest/AssertEqual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#113](https://github.com/rubocop-hq/rubocop-minitest/issues/113): This PR fixes an error for `Minitest/AssertEqual` and some cops when using `assert` with block argument. ([@koic][])
+
 ## 0.10.1 (2020-07-25)
 
 ### Bug fixes

--- a/lib/rubocop/cop/mixin/minitest_cop_rule.rb
+++ b/lib/rubocop/cop/mixin/minitest_cop_rule.rb
@@ -57,7 +57,7 @@ module RuboCop
           private
 
           def peel_redundant_parentheses_from(arguments)
-            return arguments unless arguments.first.begin_type?
+            return arguments unless arguments.first&.begin_type?
 
             peel_redundant_parentheses_from(arguments.first.children)
           end

--- a/test/rubocop/cop/minitest/assert_equal_test.rb
+++ b/test/rubocop/cop/minitest/assert_equal_test.rb
@@ -132,4 +132,11 @@ class AssertEqualTest < Minitest::Test
       end
     RUBY
   end
+
+  # See: https://github.com/rubocop-hq/rubocop-minitest/issues/113
+  def test_does_not_register_offense_when_assert_with_block_argument
+    assert_no_offenses(<<~RUBY)
+      assert { 1 + 2 == 3 }
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #113.

This PR fixes an error for `Minitest/AssertEqual` and some cops when using `assert` with block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
