### PR TITLE
[Fix #115] Fix a false positive for `Minitest/TestMethodName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#115](https://github.com/rubocop-hq/rubocop-minitest/issues/115): Fix a false positive for `Minitest/TestMethodName` for when defining test method has an argument, and test method without assertion methods. ([@koic][])
+
 ## 0.10.2 (2020-12-27)
 
 ### Bug fixes

--- a/docs/modules/ROOT/pages/cops_minitest.adoc
+++ b/docs/modules/ROOT/pages/cops_minitest.adoc
@@ -962,6 +962,7 @@ refute_respond_to(self, :do_something)
 |===
 
 This cop enforces that test method names start with `test_` prefix.
+It aims to prevent tests that aren't executed by forgetting to start test method name with `test_`.
 
 === Examples
 
@@ -978,6 +979,12 @@ end
 class FooTest < Minitest::Test
   def test_does_something
     assert_equal 42, do_something
+  end
+end
+
+# good
+class FooTest < Minitest::Test
+  def helper_method(argument)
   end
 end
 ----

--- a/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
+++ b/lib/rubocop/cop/mixin/minitest_exploration_helpers.rb
@@ -10,6 +10,15 @@ module RuboCop
 
       ASSERTION_PREFIXES = %w[assert refute].freeze
 
+      ASSERTION_METHODS = %i[
+        assert assert_empty assert_equal assert_in_delta assert_in_epsilon assert_includes assert_instance_of
+        assert_kind_of assert_match assert_nil assert_operator assert_output assert_path_exists assert_predicate
+        assert_raises assert_respond_to assert_same assert_send assert_silent assert_throws
+        refute refute_empty refute_equal refute_in_delta refute_in_epsilon refute_includes refute_instance_of
+        refute_kind_of refute_match refute_nil refute_operator refute_path_exists refute_predicate
+        refute_respond_to refute_same
+      ].freeze
+
       LIFECYCLE_HOOK_METHODS = %i[
         before_setup
         setup
@@ -74,6 +83,10 @@ module RuboCop
       def assertion?(node)
         node.send_type? &&
           ASSERTION_PREFIXES.any? { |prefix| node.method_name.to_s.start_with?(prefix) }
+      end
+
+      def assertion_method?(method_name)
+        ASSERTION_METHODS.include?(method_name)
       end
 
       def lifecycle_hook_method?(node)

--- a/test/rubocop/cop/minitest/test_method_name_test.rb
+++ b/test/rubocop/cop/minitest/test_method_name_test.rb
@@ -7,10 +7,12 @@ class TestMethodNameTest < Minitest::Test
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
+          assert_equal(expected, actual)
         end
 
         def do_something_else
             ^^^^^^^^^^^^^^^^^ Test method name should start with `test_` prefix.
+          assert_equal(expected, actual)
         end
       end
     RUBY
@@ -18,9 +20,11 @@ class TestMethodNameTest < Minitest::Test
     assert_correction(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
+          assert_equal(expected, actual)
         end
 
         def test_do_something_else
+          assert_equal(expected, actual)
         end
       end
     RUBY
@@ -39,6 +43,7 @@ class TestMethodNameTest < Minitest::Test
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def setup
+          assert_equal(expected, actual)
         end
       end
     RUBY
@@ -50,6 +55,27 @@ class TestMethodNameTest < Minitest::Test
         private
 
         def do_something
+          assert_equal(expected, actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_defining_test_method_has_an_argument
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def do_something(arg)
+          assert_equal(expected, actual)
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_defining_test_method_without_assertion_methods
+    assert_no_offenses(<<~RUBY)
+      class FooTest < Minitest::Test
+        def do_something
+          foo
         end
       end
     RUBY


### PR DESCRIPTION
Fixes #115.

This PR fixes a false positive for `Minitest/TestMethodName` for when defining test method takes no arguments, and test method without assertion methods.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
