### PR TITLE
Change `AssertEmptyLiteral` cop to check for `assert_equal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#118](https://github.com/rubocop-hq/rubocop-minitest/pull/118): **(BREAKING)** Fix `Minitest/AssertEmptyLiteral` by making it check for `assert_equal([], array)` instead of `assert([], array)`. ([@cstyles][])
+
 ## 0.10.3 (2021-01-12)
 
 ### Bug fixes
@@ -177,3 +181,4 @@
 [@andrykonchin]: https://github.com/andrykonchin
 [@fatkodima]: https://github.com/fatkodima
 [@tsmmark]: https://github.com/tsmmark
+[@cstyles]: https://github.com/cstyles

--- a/docs/modules/ROOT/pages/cops_minitest.adoc
+++ b/docs/modules/ROOT/pages/cops_minitest.adoc
@@ -45,15 +45,15 @@ assert_empty(object, 'message')
 |===
 
 This cop enforces the test to use `assert_empty`
-instead of using `assert([], object)`.
+instead of using `assert_equal([], object)`.
 
 === Examples
 
 [source,ruby]
 ----
 # bad
-assert([], object)
-assert({}, object)
+assert_equal([], object)
+assert_equal({}, object)
 
 # good
 assert_empty(object)

--- a/lib/rubocop/cop/minitest/assert_empty_literal.rb
+++ b/lib/rubocop/cop/minitest/assert_empty_literal.rb
@@ -4,12 +4,12 @@ module RuboCop
   module Cop
     module Minitest
       # This cop enforces the test to use `assert_empty`
-      # instead of using `assert([], object)`.
+      # instead of using `assert_equal([], object)`.
       #
       # @example
       #   # bad
-      #   assert([], object)
-      #   assert({}, object)
+      #   assert_equal([], object)
+      #   assert_equal({}, object)
       #
       #   # good
       #   assert_empty(object)
@@ -18,14 +18,14 @@ module RuboCop
         include ArgumentRangeHelper
 
         MSG = 'Prefer using `assert_empty(%<arguments>s)` over ' \
-              '`assert(%<literal>s, %<arguments>s)`.'
+              '`assert_equal(%<literal>s, %<arguments>s)`.'
 
-        def_node_matcher :assert_with_empty_literal, <<~PATTERN
-          (send nil? :assert ${hash array} $...)
+        def_node_matcher :assert_equal_with_empty_literal, <<~PATTERN
+          (send nil? :assert_equal ${hash array} $...)
         PATTERN
 
         def on_send(node)
-          assert_with_empty_literal(node) do |literal, matchers|
+          assert_equal_with_empty_literal(node) do |literal, matchers|
             return unless literal.values.empty?
 
             args = matchers.map(&:source).join(', ')
@@ -36,7 +36,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          assert_with_empty_literal(node) do |_literal, matchers|
+          assert_equal_with_empty_literal(node) do |_literal, matchers|
             object = matchers.first
 
             lambda do |corrector|

--- a/test/rubocop/cop/minitest/assert_empty_literal_test.rb
+++ b/test/rubocop/cop/minitest/assert_empty_literal_test.rb
@@ -7,8 +7,8 @@ class AssertEmptyLiteralTest < Minitest::Test
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          assert([], somestuff)
-          ^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)` over `assert([], somestuff)`.
+          assert_equal([], somestuff)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)` over `assert_equal([], somestuff)`.
         end
       end
     RUBY
@@ -26,8 +26,8 @@ class AssertEmptyLiteralTest < Minitest::Test
     assert_offense(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          assert({}, somestuff)
-          ^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)` over `assert({}, somestuff)`.
+          assert_equal({}, somestuff)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `assert_empty(somestuff)` over `assert_equal({}, somestuff)`.
         end
       end
     RUBY
@@ -41,7 +41,7 @@ class AssertEmptyLiteralTest < Minitest::Test
     RUBY
   end
 
-  def test_does_not_register_offense_when_using_assert_equal
+  def test_does_not_register_offense_when_asserting_non_empty_array
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
@@ -51,11 +51,11 @@ class AssertEmptyLiteralTest < Minitest::Test
     RUBY
   end
 
-  def test_does_not_register_offense_when_using_assert_with_single_parameter
+  def test_does_not_register_offense_when_asserting_two_parameters
     assert_no_offenses(<<~RUBY)
       class FooTest < Minitest::Test
         def test_do_something
-          assert(somestuff)
+          assert_equal(somestuff, someotherstuff)
         end
       end
     RUBY


### PR DESCRIPTION
While this cop is correct that we should be using `assert_empty(list)`
over `assert([], list)`, it's right for the wrong reasons. That example
is bad because it's using `assert` and not `assert_equal`. An empty
list/hash is truthy so the assertion will always succeed. That is,
`assert([], [1, 2, 3])` will succeed even though at a glance it looks
like it shouldn't. I believe that what this cop is intending to check
for is `assert_equal([], list)` instead so I've updated the references
to `assert` to `assert_equal`.

Issue #117 proposes that we try to detect when `assert` is used where
the user likely wanted `assert_equal` so while this cop will no longer
register a violation for `assert([], list)`, if that proposal is
accepted then a future cop *will* register a violation.

edit: #120 adds such a cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
