### PR TITLE
Access version correctly in `bump_minor_version`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ task :new_cop, [:cop] do |_task, args|
 end
 
 def bump_minor_version
-  major, minor, _patch = RuboCop::Minitest::VERSION.split('.')
+  major, minor, _patch = RuboCop::Minitest::Version::STRING.split('.')
 
   "#{major}.#{minor.succ}"
 end


### PR DESCRIPTION
In 2efa54df9ed2292eef89d8e5255f784de3c6f476 `VERSION` was changed to a module with a `STRING` constant but we forgot to update `bump_minor_version` in `Rakefile`. This bug prevents the `new_cop` Rake task from completing successfully.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
