### PR TITLE
Require `yaml` and `pathname` in `bin/console`

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+require 'pathname'
+require 'yaml'
 require 'rubocop/minitest'
 
 # You can add fixtures and/or initialization code here to make experimenting


### PR DESCRIPTION
The absence of the `yaml` require was preventing `bin/console` from
being able to execute. Requiring `pathname` doesn't seem to be necessary
but I threw it in too for good measure.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-minitest/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
